### PR TITLE
fix: add missing traceability markers and fix marker-scanner self-ignore

### DIFF
--- a/.awa/specs/DESIGN-CHK-check.md
+++ b/.awa/specs/DESIGN-CHK-check.md
@@ -116,7 +116,7 @@ function parseSpecs(config: CheckConfig): Promise<SpecParseResult>;
 
 Matches code markers against spec IDs. Reports orphaned markers (code references non-existent spec ID) and uncovered ACs (spec AC with no test marker).
 
-IMPLEMENTS: CHK-3_AC-1, CHK-4_AC-1, CHK-6_AC-1, CHK-14_AC-1
+IMPLEMENTS: CHK-3_AC-1, CHK-4_AC-1, CHK-6_AC-1, CHK-14_AC-1, CHK-18_AC-1, CHK-19_AC-1
 
 ```typescript
 interface CheckResult {
@@ -243,6 +243,12 @@ interface RawCheckOptions {
 - CHK_P-5 [Exit Code Correctness]: Exit code is 0 when no errors exist, 1 when errors exist (warnings alone do not affect exit code)
   VALIDATES: CHK-8_AC-1
 
+- CHK_P-6 [Component Coverage Detection]: Every DESIGN component without a corresponding `@awa-component` marker is reported as a warning
+  VALIDATES: CHK-18_AC-1
+
+- CHK_P-7 [Implementation Coverage Detection]: Every spec AC without a corresponding `@awa-impl` marker is reported as a warning
+  VALIDATES: CHK-19_AC-1
+
 ## Error Handling
 
 ### CheckError
@@ -297,8 +303,11 @@ PRINCIPLES:
 - CHK-14_AC-1 → CHK-CodeSpecChecker
 - CHK-15_AC-1 → CHK-SpecSpecChecker
 - CHK-16_AC-1 → CHK-CheckCommand
+- CHK-18_AC-1 → CHK-CodeSpecChecker (CHK_P-6)
+- CHK-19_AC-1 → CHK-CodeSpecChecker (CHK_P-7)
 
 ## Change Log
 
 - 1.0.0 (2026-02-27): Initial design
 - 1.1.0 (2026-02-27): Schema upgrade — added H3 heading under Requirements Traceability
+- 1.2.0 (2026-03-01): Added CHK-18 (uncovered component) and CHK-19 (unimplemented AC) to CodeSpecChecker; added CHK_P-6, CHK_P-7

--- a/.awa/specs/REQ-CFG-config.md
+++ b/.awa/specs/REQ-CFG-config.md
@@ -25,10 +25,10 @@ AS A developer, I WANT configuration loaded from a file, SO THAT I don't need to
 
 ACCEPTANCE CRITERIA
 
-- [ ] CFG-1_AC-1 [event]: WHEN the system starts THEN it SHALL attempt to load `.awa.toml` from the current directory
-- [ ] CFG-1_AC-2 [conditional]: IF `.awa.toml` does not exist THEN the system SHALL continue without error
-- [ ] CFG-1_AC-3 [conditional]: IF `--config <path>` is provided THEN the system SHALL load configuration from the specified path
-- [ ] CFG-1_AC-4 [event]: WHEN `--config <path>` points to a non-existent file THEN the system SHALL display an error and exit
+- CFG-1_AC-1 [event]: WHEN the system starts THEN it SHALL attempt to load `.awa.toml` from the current directory
+- CFG-1_AC-2 [conditional]: IF `.awa.toml` does not exist THEN the system SHALL continue without error
+- CFG-1_AC-3 [conditional]: IF `--config <path>` is provided THEN the system SHALL load configuration from the specified path
+- CFG-1_AC-4 [event]: WHEN `--config <path>` points to a non-existent file THEN the system SHALL display an error and exit
 
 ### CFG-2: TOML Format Support [MUST]
 
@@ -38,9 +38,9 @@ AS A developer, I WANT configuration in TOML format, SO THAT I can use a human-r
 
 ACCEPTANCE CRITERIA
 
-- [ ] CFG-2_AC-1 [ubiquitous]: The system SHALL parse configuration files as TOML format
-- [ ] CFG-2_AC-2 [event]: WHEN TOML parsing fails THEN the system SHALL display a descriptive error with line number
-- [ ] CFG-2_AC-3 [ubiquitous]: The system SHALL support TOML 1.0 specification
+- CFG-2_AC-1 [ubiquitous]: The system SHALL parse configuration files as TOML format
+- CFG-2_AC-2 [event]: WHEN TOML parsing fails THEN the system SHALL display a descriptive error with line number
+- CFG-2_AC-3 [ubiquitous]: The system SHALL support TOML 1.0 specification
 
 ### CFG-3: Supported Configuration Options [MUST]
 
@@ -50,16 +50,16 @@ AS A developer, I WANT all CLI options configurable in the file, SO THAT I can s
 
 ACCEPTANCE CRITERIA
 
-- [ ] CFG-3_AC-1 [ubiquitous]: The configuration file SHALL support `output` as a string path
-- [ ] CFG-3_AC-2 [ubiquitous]: The configuration file SHALL support `template` as a string source
-- [ ] CFG-3_AC-3 [ubiquitous]: The configuration file SHALL support `features` as an array of strings
-- [ ] CFG-3_AC-4 [ubiquitous]: The configuration file SHALL support `force` as a boolean
-- [ ] CFG-3_AC-5 [ubiquitous]: The configuration file SHALL support `dry-run` as a boolean
-- [ ] CFG-3_AC-6 [ubiquitous]: The configuration file SHALL support `refresh` as a boolean
-- [ ] CFG-3_AC-7 [ubiquitous]: The configuration file SHALL support `delete` as a boolean
-- [ ] CFG-3_AC-8 [ubiquitous]: The configuration file SHALL support `list-unknown` as a boolean
-- [ ] CFG-3_AC-9 [ubiquitous]: The configuration file SHALL support `preset` as an array of strings
-- [ ] CFG-3_AC-10 [ubiquitous]: The configuration file SHALL support `remove-features` as an array of strings
+- CFG-3_AC-1 [ubiquitous]: The configuration file SHALL support `output` as a string path
+- CFG-3_AC-2 [ubiquitous]: The configuration file SHALL support `template` as a string source
+- CFG-3_AC-3 [ubiquitous]: The configuration file SHALL support `features` as an array of strings
+- CFG-3_AC-4 [ubiquitous]: The configuration file SHALL support `force` as a boolean
+- CFG-3_AC-5 [ubiquitous]: The configuration file SHALL support `dry-run` as a boolean
+- CFG-3_AC-6 [ubiquitous]: The configuration file SHALL support `refresh` as a boolean
+- CFG-3_AC-7 [ubiquitous]: The configuration file SHALL support `delete` as a boolean
+- CFG-3_AC-8 [ubiquitous]: The configuration file SHALL support `list-unknown` as a boolean
+- CFG-3_AC-9 [ubiquitous]: The configuration file SHALL support `preset` as an array of strings
+- CFG-3_AC-10 [ubiquitous]: The configuration file SHALL support `remove-features` as an array of strings
 
 ### CFG-4: CLI Override Behavior [MUST]
 
@@ -69,10 +69,10 @@ AS A developer, I WANT CLI arguments to override config file values, SO THAT I c
 
 ACCEPTANCE CRITERIA
 
-- [ ] CFG-4_AC-1 [conditional]: IF a CLI argument is provided THEN it SHALL override the corresponding config file value
-- [ ] CFG-4_AC-2 [conditional]: IF a CLI argument is not provided THEN the config file value SHALL be used
-- [ ] CFG-4_AC-3 [conditional]: IF neither CLI argument nor config file value exists THEN the default value SHALL be used
-- [ ] CFG-4_AC-4 [ubiquitous]: The `features` array from CLI SHALL replace (not merge with) the config file array
+- CFG-4_AC-1 [conditional]: IF a CLI argument is provided THEN it SHALL override the corresponding config file value
+- CFG-4_AC-2 [conditional]: IF a CLI argument is not provided THEN the config file value SHALL be used
+- CFG-4_AC-3 [conditional]: IF neither CLI argument nor config file value exists THEN the default value SHALL be used
+- CFG-4_AC-4 [ubiquitous]: The `features` array from CLI SHALL replace (not merge with) the config file array
 
 ### CFG-5: Option Name Convention [MUST]
 
@@ -82,8 +82,8 @@ AS A developer, I WANT consistent option naming, SO THAT I can easily map betwee
 
 ACCEPTANCE CRITERIA
 
-- [ ] CFG-5_AC-1 [ubiquitous]: Configuration file options SHALL use kebab-case naming (e.g., `dry-run`)
-- [ ] CFG-5_AC-2 [ubiquitous]: CLI options SHALL use the same kebab-case names as config file options
+- CFG-5_AC-1 [ubiquitous]: Configuration file options SHALL use kebab-case naming (e.g., `dry-run`)
+- CFG-5_AC-2 [ubiquitous]: CLI options SHALL use the same kebab-case names as config file options
 
 ### CFG-6: Unknown Option Handling [SHOULD]
 
@@ -93,8 +93,8 @@ AS A developer, I WANT warnings for unknown config options, SO THAT I can catch 
 
 ACCEPTANCE CRITERIA
 
-- [ ] CFG-6_AC-1 [conditional]: IF the configuration file contains an unknown option THEN the system SHOULD display a warning
-- [ ] CFG-6_AC-2 [conditional]: IF the configuration file contains an unknown option THEN the system SHALL continue execution
+- CFG-6_AC-1 [conditional]: IF the configuration file contains an unknown option THEN the system SHOULD display a warning
+- CFG-6_AC-2 [conditional]: IF the configuration file contains an unknown option THEN the system SHALL continue execution
 
 ## Assumptions
 

--- a/.awa/specs/REQ-CHK-check.md
+++ b/.awa/specs/REQ-CHK-check.md
@@ -20,9 +20,9 @@ AS A developer, I WANT the check command to scan source files for traceability m
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-1_AC-1 [ubiquitous]: The system SHALL scan files matching configured code globs for `@awa-impl`, `@awa-test`, and `@awa-component` markers, extracting the marker type and referenced ID
-- [x] CHK-1_AC-2 [optional]: IF awa-code skill is active THEN it SHOULD instruct running `awa check` after implementation
-- [x] CHK-1_AC-3 [optional]: IF awa-refactor skill is active THEN it SHOULD instruct running `awa check` to confirm markers are preserved
+- CHK-1_AC-1 [ubiquitous]: The system SHALL scan files matching configured code globs for `@awa-impl`, `@awa-test`, and `@awa-component` markers, extracting the marker type and referenced ID
+- CHK-1_AC-2 [optional]: IF awa-code skill is active THEN it SHOULD instruct running `awa check` after implementation
+- CHK-1_AC-3 [optional]: IF awa-refactor skill is active THEN it SHOULD instruct running `awa check` to confirm markers are preserved
 
 ### CHK-2: Spec Parsing [MUST]
 
@@ -30,7 +30,7 @@ AS A developer, I WANT the check command to parse spec files for IDs, SO THAT ma
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-2_AC-1 [ubiquitous]: The system SHALL parse files matching configured spec globs to extract requirement IDs, AC IDs, property IDs, and component names
+- CHK-2_AC-1 [ubiquitous]: The system SHALL parse files matching configured spec globs to extract requirement IDs, AC IDs, property IDs, and component names
 
 ### CHK-3: Orphaned Marker Detection [MUST]
 
@@ -38,7 +38,7 @@ AS A developer, I WANT orphaned markers reported as errors, SO THAT I can fix st
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-3_AC-1 [conditional]: IF a code marker references an ID that does not exist in any parsed spec file THEN the system SHALL report it as an error
+- CHK-3_AC-1 [conditional]: IF a code marker references an ID that does not exist in any parsed spec file THEN the system SHALL report it as an error
 
 DEPENDS ON: CHK-1, CHK-2
 
@@ -48,7 +48,7 @@ AS A developer, I WANT uncovered ACs reported, SO THAT I know which criteria lac
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-4_AC-1 [conditional]: IF a spec AC has no `@awa-test` marker referencing it in any code file THEN the system SHALL report it as a warning
+- CHK-4_AC-1 [conditional]: IF a spec AC has no `@awa-test` marker referencing it in any code file THEN the system SHALL report it as a warning
 
 DEPENDS ON: CHK-1, CHK-2
 
@@ -58,9 +58,9 @@ AS A developer, I WANT broken cross-references between spec files reported, SO T
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-5_AC-1 [conditional]: IF a DESIGN file IMPLEMENTS or VALIDATES reference does not resolve to a real REQ ID or AC ID THEN the system SHALL report it as an error
-- [x] CHK-5_AC-2 [optional]: IF awa-requirements skill is active THEN it SHOULD instruct running `awa check` after updating requirements
-- [x] CHK-5_AC-3 [optional]: IF awa-design skill is active THEN it SHOULD instruct running `awa check` after updating design
+- CHK-5_AC-1 [conditional]: IF a DESIGN file IMPLEMENTS or VALIDATES reference does not resolve to a real REQ ID or AC ID THEN the system SHALL report it as an error
+- CHK-5_AC-2 [optional]: IF awa-requirements skill is active THEN it SHOULD instruct running `awa check` after updating requirements
+- CHK-5_AC-3 [optional]: IF awa-design skill is active THEN it SHOULD instruct running `awa check` after updating design
 
 DEPENDS ON: CHK-2
 
@@ -70,7 +70,7 @@ AS A developer, I WANT malformed IDs detected, SO THAT naming conventions are en
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-6_AC-1 [conditional]: IF a marker references an ID that does not match the configured ID pattern regex THEN the system SHALL report it as an error
+- CHK-6_AC-1 [conditional]: IF a marker references an ID that does not match the configured ID pattern regex THEN the system SHALL report it as an error
 
 ### CHK-7: Orphaned Spec Warning [MUST]
 
@@ -78,7 +78,7 @@ AS A developer, I WANT orphaned spec files flagged as warnings, SO THAT I am awa
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-7_AC-1 [conditional]: IF a spec file's CODE prefix is not referenced by any other spec file or code marker THEN the system SHALL report it as a warning
+- CHK-7_AC-1 [conditional]: IF a spec file's CODE prefix is not referenced by any other spec file or code marker THEN the system SHALL report it as a warning
 
 DEPENDS ON: CHK-2
 
@@ -88,7 +88,7 @@ AS A CI system, I WANT deterministic exit codes, SO THAT validation results can 
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-8_AC-1 [ubiquitous]: The system SHALL exit with code 0 when no errors or warnings are found, exit with code 1 when errors or warnings are found, unless `--allow-warnings` is active
+- CHK-8_AC-1 [ubiquitous]: The system SHALL exit with code 0 when no errors or warnings are found, exit with code 1 when errors or warnings are found, unless `--allow-warnings` is active
 
 DEPENDS ON: CHK-3, CHK-17
 
@@ -98,7 +98,7 @@ AS A CI engineer, I WANT JSON output, SO THAT validation results can be parsed p
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-9_AC-1 [conditional]: IF `--format json` is specified THEN the system SHALL output results as valid JSON to stdout
+- CHK-9_AC-1 [conditional]: IF `--format json` is specified THEN the system SHALL output results as valid JSON to stdout
 
 DEPENDS ON: CHK-3
 
@@ -108,7 +108,7 @@ AS A developer, I WANT to exclude paths from validation, SO THAT irrelevant file
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-10_AC-1 [conditional]: IF `--ignore` patterns are provided THEN the system SHALL exclude matching paths from scanning
+- CHK-10_AC-1 [conditional]: IF `--ignore` patterns are provided THEN the system SHALL exclude matching paths from scanning
 
 ### CHK-11: Configurable Markers [SHOULD]
 
@@ -116,7 +116,7 @@ AS A template author, I WANT configurable marker names, SO THAT custom workflows
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-11_AC-1 [conditional]: IF `[check].markers` is set in config THEN the system SHALL use those marker names instead of defaults
+- CHK-11_AC-1 [conditional]: IF `[check].markers` is set in config THEN the system SHALL use those marker names instead of defaults
 
 DEPENDS ON: CHK-1
 
@@ -126,7 +126,7 @@ AS A template author, I WANT configurable spec file globs, SO THAT custom projec
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-12_AC-1 [conditional]: IF `[check].spec-globs` is set in config THEN the system SHALL use those globs instead of defaults
+- CHK-12_AC-1 [conditional]: IF `[check].spec-globs` is set in config THEN the system SHALL use those globs instead of defaults
 
 DEPENDS ON: CHK-2
 
@@ -136,7 +136,7 @@ AS A template author, I WANT configurable code file globs, SO THAT custom projec
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-13_AC-1 [conditional]: IF `[check].code-globs` is set in config THEN the system SHALL use those globs instead of defaults
+- CHK-13_AC-1 [conditional]: IF `[check].code-globs` is set in config THEN the system SHALL use those globs instead of defaults
 
 DEPENDS ON: CHK-1
 
@@ -146,7 +146,7 @@ AS A template author, I WANT a configurable ID pattern regex, SO THAT custom nam
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-14_AC-1 [conditional]: IF `[check].id-pattern` is set in config THEN the system SHALL use that regex for ID format validation instead of the default
+- CHK-14_AC-1 [conditional]: IF `[check].id-pattern` is set in config THEN the system SHALL use that regex for ID format validation instead of the default
 
 DEPENDS ON: CHK-6
 
@@ -156,7 +156,7 @@ AS A template author, I WANT configurable cross-reference keywords, SO THAT cust
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-15_AC-1 [conditional]: IF `[check].cross-ref-patterns` is set in config THEN the system SHALL use those patterns instead of defaults
+- CHK-15_AC-1 [conditional]: IF `[check].cross-ref-patterns` is set in config THEN the system SHALL use those patterns instead of defaults
 
 DEPENDS ON: CHK-5
 
@@ -166,7 +166,7 @@ AS A developer using the bundled awa workflow, I WANT all configuration to have 
 
 ACCEPTANCE CRITERIA
 
-- [x] CHK-16_AC-1 [ubiquitous]: The system SHALL provide default values for all check configuration that match the bundled awa template workflow
+- CHK-16_AC-1 [ubiquitous]: The system SHALL provide default values for all check configuration that match the bundled awa template workflow
 
 DEPENDS ON: CHK-11, CHK-12, CHK-13, CHK-14, CHK-15
 
@@ -176,11 +176,31 @@ AS A developer, I WANT an `--allow-warnings` flag, SO THAT I can opt into the pr
 
 ACCEPTANCE CRITERIA
 
-- [ ] CHK-17_AC-1 [conditional]: IF `--allow-warnings` is specified THEN the system SHALL exit with code 0 when only warnings are found
-- [ ] CHK-17_AC-2 [conditional]: IF `[check].allow-warnings` is set to `true` in config THEN the system SHALL treat it the same as `--allow-warnings`
-- [ ] CHK-17_AC-3 [ubiquitous]: The system SHALL default `allow-warnings` to `false` (warnings are errors by default)
+- CHK-17_AC-1 [conditional]: IF `--allow-warnings` is specified THEN the system SHALL exit with code 0 when only warnings are found
+- CHK-17_AC-2 [conditional]: IF `[check].allow-warnings` is set to `true` in config THEN the system SHALL treat it the same as `--allow-warnings`
+- CHK-17_AC-3 [ubiquitous]: The system SHALL default `allow-warnings` to `false` (warnings are errors by default)
 
 DEPENDS ON: CHK-8
+
+### CHK-18: Uncovered Component Detection [SHOULD]
+
+AS A developer, I WANT uncovered DESIGN components reported, SO THAT I know which components lack a corresponding `@awa-component` marker in code.
+
+ACCEPTANCE CRITERIA
+
+- CHK-18_AC-1 [conditional]: IF a DESIGN component has no `@awa-component` marker referencing it in any code file THEN the system SHALL report it as a warning
+
+DEPENDS ON: CHK-1, CHK-2
+
+### CHK-19: Unimplemented AC Detection [SHOULD]
+
+AS A developer, I WANT unimplemented ACs reported, SO THAT I know which acceptance criteria lack an `@awa-impl` marker in code.
+
+ACCEPTANCE CRITERIA
+
+- CHK-19_AC-1 [conditional]: IF a spec AC has no `@awa-impl` marker referencing it in any code file THEN the system SHALL report it as a warning
+
+DEPENDS ON: CHK-1, CHK-2
 
 ## Assumptions
 
@@ -203,3 +223,4 @@ DEPENDS ON: CHK-8
 
 - 1.0.0 (2026-02-27): Initial requirements
 - 1.1.0 (2026-02-28): CHK-8 updated — warnings are now errors by default; added CHK-17 `--allow-warnings` flag
+- 1.2.0 (2026-03-01): Added CHK-18 (uncovered component detection) and CHK-19 (unimplemented AC detection)

--- a/.awa/specs/REQ-CLI-cli.md
+++ b/.awa/specs/REQ-CLI-cli.md
@@ -24,11 +24,11 @@ AS A developer, I WANT a clear command structure, SO THAT I can easily invoke ge
 
 ACCEPTANCE CRITERIA
 
-- [ ] CLI-1_AC-1 [ubiquitous]: The system SHALL provide a `generate` command as the primary entry point
-- [ ] CLI-1_AC-2 [event]: WHEN the user invokes `awa` without a command THEN the system SHALL display help information
-- [ ] CLI-1_AC-3 [ubiquitous]: The system SHALL accept an output directory as the first positional argument: `awa generate <output>`
-- [ ] CLI-1_AC-4 [conditional]: IF the user invokes `awa generate` without an output directory AND no output is specified in config THEN the system SHALL display an error and usage information
-- [ ] CLI-1_AC-5 [ubiquitous]: The help output SHALL display the positional argument syntax in the usage line
+- CLI-1_AC-1 [ubiquitous]: The system SHALL provide a `generate` command as the primary entry point
+- CLI-1_AC-2 [event]: WHEN the user invokes `awa` without a command THEN the system SHALL display help information
+- CLI-1_AC-3 [ubiquitous]: The system SHALL accept an output directory as the first positional argument: `awa generate <output>`
+- CLI-1_AC-4 [conditional]: IF the user invokes `awa generate` without an output directory AND no output is specified in config THEN the system SHALL display an error and usage information
+- CLI-1_AC-5 [ubiquitous]: The help output SHALL display the positional argument syntax in the usage line
 
 ### CLI-2: Output Directory Argument [MUST]
 
@@ -38,12 +38,12 @@ AS A developer, I WANT to specify an output directory, SO THAT generated files g
 
 ACCEPTANCE CRITERIA
 
-- [ ] CLI-2_AC-1 [ubiquitous]: The system SHALL accept an output directory as an optional positional argument
-- [ ] CLI-2_AC-2 [state]: WHEN output is provided as positional argument THEN the system SHALL use it regardless of config file value
-- [ ] CLI-2_AC-3 [state]: WHEN output is not provided as positional argument THEN the system SHALL use the value from config file
-- [ ] CLI-2_AC-4 [state]: WHEN output is not provided via CLI or config THEN the system SHALL display an error
-- [ ] CLI-2_AC-5 [ubiquitous]: The system SHALL accept both relative and absolute paths for the output directory
-- [ ] CLI-2_AC-6 [ubiquitous]: The system SHALL accept `.` to specify the current working directory
+- CLI-2_AC-1 [ubiquitous]: The system SHALL accept an output directory as an optional positional argument
+- CLI-2_AC-2 [state]: WHEN output is provided as positional argument THEN the system SHALL use it regardless of config file value
+- CLI-2_AC-3 [state]: WHEN output is not provided as positional argument THEN the system SHALL use the value from config file
+- CLI-2_AC-4 [state]: WHEN output is not provided via CLI or config THEN the system SHALL display an error
+- CLI-2_AC-5 [ubiquitous]: The system SHALL accept both relative and absolute paths for the output directory
+- CLI-2_AC-6 [ubiquitous]: The system SHALL accept `.` to specify the current working directory
 
 ### CLI-3: Template Source Option [MUST]
 
@@ -53,9 +53,9 @@ AS A developer, I WANT to specify a template source, SO THAT I can use custom te
 
 ACCEPTANCE CRITERIA
 
-- [ ] CLI-3_AC-1 [ubiquitous]: The system SHALL accept `--template <source>` to specify the template source
-- [ ] CLI-3_AC-2 [state]: WHEN `--template` is not provided THEN the system SHALL use bundled default templates
-- [ ] CLI-3_AC-3 [ubiquitous]: The system SHALL accept local paths, Git shorthand, and full Git URLs as template sources
+- CLI-3_AC-1 [ubiquitous]: The system SHALL accept `--template <source>` to specify the template source
+- CLI-3_AC-2 [state]: WHEN `--template` is not provided THEN the system SHALL use bundled default templates
+- CLI-3_AC-3 [ubiquitous]: The system SHALL accept local paths, Git shorthand, and full Git URLs as template sources
 
 ### CLI-4: Feature Flags Option [MUST]
 
@@ -65,9 +65,9 @@ AS A developer, I WANT to pass feature flags, SO THAT templates can conditionall
 
 ACCEPTANCE CRITERIA
 
-- [ ] CLI-4_AC-1 [ubiquitous]: The system SHALL accept `--features <flag>...` as a variadic option
-- [ ] CLI-4_AC-2 [event]: WHEN multiple features are provided THEN the system SHALL collect all values into an array
-- [ ] CLI-4_AC-3 [state]: WHEN `--features` is not provided THEN the system SHALL use an empty array as default
+- CLI-4_AC-1 [ubiquitous]: The system SHALL accept `--features <flag>...` as a variadic option
+- CLI-4_AC-2 [event]: WHEN multiple features are provided THEN the system SHALL collect all values into an array
+- CLI-4_AC-3 [state]: WHEN `--features` is not provided THEN the system SHALL use an empty array as default
 
 ### CLI-5: Force Overwrite Option [MUST]
 
@@ -77,9 +77,9 @@ AS A developer, I WANT to force overwrite existing files, SO THAT I can regenera
 
 ACCEPTANCE CRITERIA
 
-- [ ] CLI-5_AC-1 [ubiquitous]: The system SHALL accept `--force` flag to enable automatic overwriting
-- [ ] CLI-5_AC-2 [conditional]: IF `--force` is provided THEN the system SHALL overwrite existing files without prompting
-- [ ] CLI-5_AC-3 [state]: WHEN `--force` is not provided THEN the system SHALL prompt for each file conflict
+- CLI-5_AC-1 [ubiquitous]: The system SHALL accept `--force` flag to enable automatic overwriting
+- CLI-5_AC-2 [conditional]: IF `--force` is provided THEN the system SHALL overwrite existing files without prompting
+- CLI-5_AC-3 [state]: WHEN `--force` is not provided THEN the system SHALL prompt for each file conflict
 
 ### CLI-6: Dry Run Option [MUST]
 
@@ -89,9 +89,9 @@ AS A developer, I WANT a dry-run mode, SO THAT I can preview what would be gener
 
 ACCEPTANCE CRITERIA
 
-- [ ] CLI-6_AC-1 [ubiquitous]: The system SHALL accept `--dry-run` flag to enable simulation mode
-- [ ] CLI-6_AC-2 [conditional]: IF `--dry-run` is provided THEN the system SHALL NOT write any files to disk
-- [ ] CLI-6_AC-3 [conditional]: IF `--dry-run` is provided THEN the system SHALL display what files would be created, skipped, or overwritten
+- CLI-6_AC-1 [ubiquitous]: The system SHALL accept `--dry-run` flag to enable simulation mode
+- CLI-6_AC-2 [conditional]: IF `--dry-run` is provided THEN the system SHALL NOT write any files to disk
+- CLI-6_AC-3 [conditional]: IF `--dry-run` is provided THEN the system SHALL display what files would be created, skipped, or overwritten
 
 ### CLI-7: Configuration File Option [MUST]
 
@@ -101,8 +101,8 @@ AS A developer, I WANT to specify an alternate config file, SO THAT I can use pr
 
 ACCEPTANCE CRITERIA
 
-- [ ] CLI-7_AC-1 [ubiquitous]: The system SHALL accept `--config <path>` to specify an alternate configuration file
-- [ ] CLI-7_AC-2 [state]: WHEN `--config` is not provided THEN the system SHALL look for `.awa.toml` in the current directory
+- CLI-7_AC-1 [ubiquitous]: The system SHALL accept `--config <path>` to specify an alternate configuration file
+- CLI-7_AC-2 [state]: WHEN `--config` is not provided THEN the system SHALL look for `.awa.toml` in the current directory
 
 ### CLI-8: Template Refresh Option [MUST]
 
@@ -112,8 +112,8 @@ AS A developer, I WANT to refresh cached templates, SO THAT I can get the latest
 
 ACCEPTANCE CRITERIA
 
-- [ ] CLI-8_AC-1 [ubiquitous]: The system SHALL accept `--refresh` flag to force re-fetch of cached templates
-- [ ] CLI-8_AC-2 [conditional]: IF `--refresh` is provided AND template source is a Git repository THEN the system SHALL re-fetch the template regardless of cache state
+- CLI-8_AC-1 [ubiquitous]: The system SHALL accept `--refresh` flag to force re-fetch of cached templates
+- CLI-8_AC-2 [conditional]: IF `--refresh` is provided AND template source is a Git repository THEN the system SHALL re-fetch the template regardless of cache state
 
 ### CLI-9: Help Display [MUST]
 
@@ -123,9 +123,9 @@ AS A developer, I WANT to view help information, SO THAT I understand available 
 
 ACCEPTANCE CRITERIA
 
-- [ ] CLI-9_AC-1 [event]: WHEN the user invokes `awa --help` or `awa -h` THEN the system SHALL display usage information
-- [ ] CLI-9_AC-2 [event]: WHEN the user invokes `awa generate --help` THEN the system SHALL display generate command options
-- [ ] CLI-9_AC-3 [ubiquitous]: The help output SHALL list all available options with descriptions
+- CLI-9_AC-1 [event]: WHEN the user invokes `awa --help` or `awa -h` THEN the system SHALL display usage information
+- CLI-9_AC-2 [event]: WHEN the user invokes `awa generate --help` THEN the system SHALL display generate command options
+- CLI-9_AC-3 [ubiquitous]: The help output SHALL list all available options with descriptions
 
 ### CLI-10: Version Display [MUST]
 
@@ -135,8 +135,8 @@ AS A developer, I WANT to view the version, SO THAT I can verify which version i
 
 ACCEPTANCE CRITERIA
 
-- [ ] CLI-10_AC-1 [event]: WHEN the user invokes `awa --version` or `awa -v` THEN the system SHALL display the version number
-- [ ] CLI-10_AC-2 [ubiquitous]: The version output SHALL match the version in package.json
+- CLI-10_AC-1 [event]: WHEN the user invokes `awa --version` or `awa -v` THEN the system SHALL display the version number
+- CLI-10_AC-2 [ubiquitous]: The version output SHALL match the version in package.json
 
 ### CLI-11: Input Validation [MUST]
 
@@ -146,9 +146,9 @@ AS A developer, I WANT clear error messages for invalid input, SO THAT I can cor
 
 ACCEPTANCE CRITERIA
 
-- [ ] CLI-11_AC-1 [event]: WHEN an unknown option is provided THEN the system SHALL display an error with the unknown option name
-- [ ] CLI-11_AC-2 [event]: WHEN a required option value is missing THEN the system SHALL display an error indicating the missing value
-- [ ] CLI-11_AC-3 [event]: WHEN validation fails THEN the system SHALL exit with a non-zero exit code
+- CLI-11_AC-1 [event]: WHEN an unknown option is provided THEN the system SHALL display an error with the unknown option name
+- CLI-11_AC-2 [event]: WHEN a required option value is missing THEN the system SHALL display an error indicating the missing value
+- CLI-11_AC-3 [event]: WHEN validation fails THEN the system SHALL exit with a non-zero exit code
 
 ### CLI-12: Delete Enable Option [MUST]
 
@@ -158,9 +158,9 @@ AS A developer, I WANT to opt-in to file deletions, SO THAT stale files from pre
 
 ACCEPTANCE CRITERIA
 
-- [ ] CLI-12_AC-1 [ubiquitous]: The system SHALL accept `--delete` flag to enable deletion of files listed in the delete list
-- [ ] CLI-12_AC-2 [conditional]: IF `--delete` is not provided THEN the system SHALL warn about files eligible for deletion without deleting them
-- [ ] CLI-12_AC-3 [conditional]: IF `--delete` is provided THEN the system SHALL proceed with delete list processing
+- CLI-12_AC-1 [ubiquitous]: The system SHALL accept `--delete` flag to enable deletion of files listed in the delete list
+- CLI-12_AC-2 [conditional]: IF `--delete` is not provided THEN the system SHALL warn about files eligible for deletion without deleting them
+- CLI-12_AC-3 [conditional]: IF `--delete` is provided THEN the system SHALL proceed with delete list processing
 
 ### CLI-13: Preset Option [MUST]
 
@@ -170,8 +170,8 @@ AS A developer, I WANT to activate feature presets from the command line, SO THA
 
 ACCEPTANCE CRITERIA
 
-- [ ] CLI-13_AC-1 [ubiquitous]: The system SHALL accept `--preset <name...>` as a variadic option
-- [ ] CLI-13_AC-2 [event]: WHEN multiple `--preset` options are provided THEN the system SHALL collect all values
+- CLI-13_AC-1 [ubiquitous]: The system SHALL accept `--preset <name...>` as a variadic option
+- CLI-13_AC-2 [event]: WHEN multiple `--preset` options are provided THEN the system SHALL collect all values
 
 ### CLI-14: Remove Features Option [MUST]
 
@@ -181,8 +181,8 @@ AS A developer, I WANT to remove specific features from the command line, SO THA
 
 ACCEPTANCE CRITERIA
 
-- [ ] CLI-14_AC-1 [ubiquitous]: The system SHALL accept `--remove-features <flag...>` as a variadic option
-- [ ] CLI-14_AC-2 [event]: WHEN multiple `--remove-features` options are provided THEN the system SHALL collect all values
+- CLI-14_AC-1 [ubiquitous]: The system SHALL accept `--remove-features <flag...>` as a variadic option
+- CLI-14_AC-2 [event]: WHEN multiple `--remove-features` options are provided THEN the system SHALL collect all values
 
 ## Assumptions
 

--- a/.awa/specs/REQ-DIFF-diff.md
+++ b/.awa/specs/REQ-DIFF-diff.md
@@ -25,9 +25,9 @@ AS A developer, I WANT templates generated to a temporary directory, SO THAT the
 
 ACCEPTANCE CRITERIA
 
-- [ ] DIFF-1_AC-1 [event]: WHEN `awa diff` is invoked THEN the system SHALL create a temporary directory using Node.js `os.tmpdir()`
-- [ ] DIFF-1_AC-2 [ubiquitous]: The system SHALL generate all templates into the temporary directory before comparison
-- [ ] DIFF-1_AC-3 [ubiquitous]: The system SHALL NOT write any files to the target directory during diff operations
+- DIFF-1_AC-1 [event]: WHEN `awa diff` is invoked THEN the system SHALL create a temporary directory using Node.js `os.tmpdir()`
+- DIFF-1_AC-2 [ubiquitous]: The system SHALL generate all templates into the temporary directory before comparison
+- DIFF-1_AC-3 [ubiquitous]: The system SHALL NOT write any files to the target directory during diff operations
 
 ### DIFF-2: File Comparison [MUST]
 
@@ -37,11 +37,11 @@ AS A developer, I WANT exact byte-for-byte comparison, SO THAT whitespace and fo
 
 ACCEPTANCE CRITERIA
 
-- [ ] DIFF-2_AC-1 [ubiquitous]: The system SHALL compare files using exact byte-for-byte comparison
-- [ ] DIFF-2_AC-2 [ubiquitous]: The system SHALL use the `diff` npm package for cross-platform unified diff generation
-- [ ] DIFF-2_AC-3 [conditional]: IF files are identical THEN the system SHALL count them as matching
-- [ ] DIFF-2_AC-4 [conditional]: IF text files differ THEN the system SHALL compute a unified diff and display it to the console
-- [ ] DIFF-2_AC-5 [conditional]: IF binary files differ THEN the system SHALL display "binary files differ" without diff content
+- DIFF-2_AC-1 [ubiquitous]: The system SHALL compare files using exact byte-for-byte comparison
+- DIFF-2_AC-2 [ubiquitous]: The system SHALL use the `diff` npm package for cross-platform unified diff generation
+- DIFF-2_AC-3 [conditional]: IF files are identical THEN the system SHALL count them as matching
+- DIFF-2_AC-4 [conditional]: IF text files differ THEN the system SHALL compute a unified diff and display it to the console
+- DIFF-2_AC-5 [conditional]: IF binary files differ THEN the system SHALL display "binary files differ" without diff content
 
 ### DIFF-3: Missing File Detection [MUST]
 
@@ -51,10 +51,10 @@ AS A developer, I WANT to see newly generated files, and optionally target-only 
 
 ACCEPTANCE CRITERIA
 
-- [ ] DIFF-3_AC-1 [conditional]: IF a generated file has no corresponding target file THEN the system SHALL report it as "new file"
-- [ ] DIFF-3_AC-2 [conditional]: IF the `--list-unknown` flag is provided AND a target file has no corresponding generated file THEN the system SHALL report it as "extra file in target"
-- [ ] DIFF-3_AC-3 [conditional]: IF the `--list-unknown` flag is NOT provided THEN the system SHALL ignore target-only files in diff results and summary
-- [ ] DIFF-3_AC-4 [ubiquitous]: The system SHALL include missing file information in the diff output according to the flag behaviour
+- DIFF-3_AC-1 [conditional]: IF a generated file has no corresponding target file THEN the system SHALL report it as "new file"
+- DIFF-3_AC-2 [conditional]: IF the `--list-unknown` flag is provided AND a target file has no corresponding generated file THEN the system SHALL report it as "extra file in target"
+- DIFF-3_AC-3 [conditional]: IF the `--list-unknown` flag is NOT provided THEN the system SHALL ignore target-only files in diff results and summary
+- DIFF-3_AC-4 [ubiquitous]: The system SHALL include missing file information in the diff output according to the flag behaviour
 
 ### DIFF-4: Diff Output Format [MUST]
 
@@ -64,11 +64,11 @@ AS A developer, I WANT git-style unified diff output with color, SO THAT differe
 
 ACCEPTANCE CRITERIA
 
-- [ ] DIFF-4_AC-1 [ubiquitous]: The system SHALL produce unified diff format output for each differing file
-- [ ] DIFF-4_AC-2 [ubiquitous]: The diff output SHALL use git-style formatting with file headers
-- [ ] DIFF-4_AC-3 [conditional]: IF the terminal supports color THEN the system SHALL colorize diff output — additions green, deletions red
-- [ ] DIFF-4_AC-4 [event]: WHEN all files match THEN the system SHALL display a success message indicating no differences
-- [ ] DIFF-4_AC-5 [ubiquitous]: The system SHALL display a summary line with file count and difference count — e.g., "3 files compared, 0 differences"
+- DIFF-4_AC-1 [ubiquitous]: The system SHALL produce unified diff format output for each differing file
+- DIFF-4_AC-2 [ubiquitous]: The diff output SHALL use git-style formatting with file headers
+- DIFF-4_AC-3 [conditional]: IF the terminal supports color THEN the system SHALL colorize diff output — additions green, deletions red
+- DIFF-4_AC-4 [event]: WHEN all files match THEN the system SHALL display a success message indicating no differences
+- DIFF-4_AC-5 [ubiquitous]: The system SHALL display a summary line with file count and difference count — e.g., "3 files compared, 0 differences"
 
 ### DIFF-5: Exit Codes [MUST]
 
@@ -78,9 +78,9 @@ AS A CI system, I WANT predictable exit codes, SO THAT I can automate template d
 
 ACCEPTANCE CRITERIA
 
-- [ ] DIFF-5_AC-1 [event]: WHEN all files match THEN the system SHALL exit with code 0
-- [ ] DIFF-5_AC-2 [event]: WHEN any differences are found THEN the system SHALL exit with code 1
-- [ ] DIFF-5_AC-3 [event]: WHEN an error occurs THEN the system SHALL exit with code 2
+- DIFF-5_AC-1 [event]: WHEN all files match THEN the system SHALL exit with code 0
+- DIFF-5_AC-2 [event]: WHEN any differences are found THEN the system SHALL exit with code 1
+- DIFF-5_AC-3 [event]: WHEN an error occurs THEN the system SHALL exit with code 2
 
 ### DIFF-6: Temp Directory Cleanup [MUST]
 
@@ -90,9 +90,9 @@ AS A developer, I WANT the temp directory cleaned up automatically, SO THAT disk
 
 ACCEPTANCE CRITERIA
 
-- [ ] DIFF-6_AC-1 [event]: WHEN diff completes successfully THEN the system SHALL delete the temporary directory
-- [ ] DIFF-6_AC-2 [event]: WHEN diff encounters an error THEN the system SHALL still delete the temporary directory
-- [ ] DIFF-6_AC-3 [ubiquitous]: The system SHALL use try/finally or equivalent to ensure cleanup occurs
+- DIFF-6_AC-1 [event]: WHEN diff completes successfully THEN the system SHALL delete the temporary directory
+- DIFF-6_AC-2 [event]: WHEN diff encounters an error THEN the system SHALL still delete the temporary directory
+- DIFF-6_AC-3 [ubiquitous]: The system SHALL use try/finally or equivalent to ensure cleanup occurs
 
 ### DIFF-7: CLI Options [MUST]
 
@@ -102,19 +102,19 @@ AS A developer, I WANT `diff` to share options with `generate`, SO THAT I can us
 
 ACCEPTANCE CRITERIA
 
-- [ ] DIFF-7_AC-1 [ubiquitous]: The system SHALL accept a target directory as an optional positional argument
-- [ ] DIFF-7_AC-2 [state]: WHEN target is provided as positional argument THEN the system SHALL use it regardless of config file value
-- [ ] DIFF-7_AC-3 [state]: WHEN target is not provided as positional argument THEN the system SHALL use the output value from config file
-- [ ] DIFF-7_AC-4 [state]: WHEN target is not provided via CLI or config THEN the system SHALL display an error
-- [ ] DIFF-7_AC-5 [ubiquitous]: The system SHALL accept both relative and absolute paths for the target directory
-- [ ] DIFF-7_AC-6 [ubiquitous]: The system SHALL accept `--template <source>` to specify the template source
-- [ ] DIFF-7_AC-7 [ubiquitous]: The system SHALL accept `--features <flag>...` as a variadic option
-- [ ] DIFF-7_AC-8 [ubiquitous]: The system SHALL accept `--config <path>` to specify an alternate configuration file
-- [ ] DIFF-7_AC-9 [ubiquitous]: The system SHALL accept `--refresh` flag to force re-fetch of cached templates
-- [ ] DIFF-7_AC-10 [ubiquitous]: The system SHALL NOT accept `--force`, `--dry-run`, or `--delete` flags — they are not applicable to diff
-- [ ] DIFF-7_AC-11 [ubiquitous]: The system SHALL accept `--list-unknown` to include target-only files in diff results
-- [ ] DIFF-7_AC-12 [ubiquitous]: The system SHALL accept `--preset <name>...` as a variadic option
-- [ ] DIFF-7_AC-13 [ubiquitous]: The system SHALL accept `--remove-features <flag>...` as a variadic option
+- DIFF-7_AC-1 [ubiquitous]: The system SHALL accept a target directory as an optional positional argument
+- DIFF-7_AC-2 [state]: WHEN target is provided as positional argument THEN the system SHALL use it regardless of config file value
+- DIFF-7_AC-3 [state]: WHEN target is not provided as positional argument THEN the system SHALL use the output value from config file
+- DIFF-7_AC-4 [state]: WHEN target is not provided via CLI or config THEN the system SHALL display an error
+- DIFF-7_AC-5 [ubiquitous]: The system SHALL accept both relative and absolute paths for the target directory
+- DIFF-7_AC-6 [ubiquitous]: The system SHALL accept `--template <source>` to specify the template source
+- DIFF-7_AC-7 [ubiquitous]: The system SHALL accept `--features <flag>...` as a variadic option
+- DIFF-7_AC-8 [ubiquitous]: The system SHALL accept `--config <path>` to specify an alternate configuration file
+- DIFF-7_AC-9 [ubiquitous]: The system SHALL accept `--refresh` flag to force re-fetch of cached templates
+- DIFF-7_AC-10 [ubiquitous]: The system SHALL NOT accept `--force`, `--dry-run`, or `--delete` flags — they are not applicable to diff
+- DIFF-7_AC-11 [ubiquitous]: The system SHALL accept `--list-unknown` to include target-only files in diff results
+- DIFF-7_AC-12 [ubiquitous]: The system SHALL accept `--preset <name>...` as a variadic option
+- DIFF-7_AC-13 [ubiquitous]: The system SHALL accept `--remove-features <flag>...` as a variadic option
 
 DEPENDS ON: CLI-2, CLI-3, CLI-4, CLI-7, CLI-8, CLI-13, CLI-14
 
@@ -126,10 +126,10 @@ AS A developer, I WANT to see which target files are listed for deletion in the 
 
 ACCEPTANCE CRITERIA
 
-- [ ] DIFF-8_AC-1 [conditional]: IF a file in `_delete.txt` exists in the target directory AND is not in the generated set THEN the system SHALL report it as "delete-listed"
-- [ ] DIFF-8_AC-2 [conditional]: IF a file is reported as both "extra" and "delete-listed" THEN the system SHALL report it only as "delete-listed"
-- [ ] DIFF-8_AC-3 [ubiquitous]: Delete-listed file reporting SHALL respect feature-gated sections in `_delete.txt`
-- [ ] DIFF-8_AC-4 [ubiquitous]: Delete-listed files SHALL count as differences in the exit code and summary
+- DIFF-8_AC-1 [conditional]: IF a file in `_delete.txt` exists in the target directory AND is not in the generated set THEN the system SHALL report it as "delete-listed"
+- DIFF-8_AC-2 [conditional]: IF a file is reported as both "extra" and "delete-listed" THEN the system SHALL report it only as "delete-listed"
+- DIFF-8_AC-3 [ubiquitous]: Delete-listed file reporting SHALL respect feature-gated sections in `_delete.txt`
+- DIFF-8_AC-4 [ubiquitous]: Delete-listed files SHALL count as differences in the exit code and summary
 
 ## Assumptions
 

--- a/.awa/specs/REQ-DISC-feature-discovery.md
+++ b/.awa/specs/REQ-DISC-feature-discovery.md
@@ -18,7 +18,7 @@ AS A developer, I WANT the features command to scan all template files recursive
 
 ACCEPTANCE CRITERIA
 
-- [x] DISC-1_AC-1 [ubiquitous]: The system SHALL recursively walk all files in the resolved template directory and read their content for feature flag extraction
+- DISC-1_AC-1 [ubiquitous]: The system SHALL recursively walk all files in the resolved template directory and read their content for feature flag extraction
 
 ### DISC-2: Feature Flag Extraction [MUST]
 
@@ -26,7 +26,7 @@ AS A developer, I WANT the features command to extract flag names from template 
 
 ACCEPTANCE CRITERIA
 
-- [x] DISC-2_AC-1 [ubiquitous]: The system SHALL extract flag names from `it.features.includes('...')`, `it.features.includes("...")`, `it.features.indexOf('...')`, and `it.features.indexOf("...")` patterns
+- DISC-2_AC-1 [ubiquitous]: The system SHALL extract flag names from `it.features.includes('...')`, `it.features.includes("...")`, `it.features.indexOf('...')`, and `it.features.indexOf("...")` patterns
 
 ### DISC-3: Feature-to-File Aggregation [MUST]
 
@@ -34,7 +34,7 @@ AS A developer, I WANT each flag listed with the files that reference it, SO THA
 
 ACCEPTANCE CRITERIA
 
-- [x] DISC-3_AC-1 [ubiquitous]: The system SHALL aggregate discovered flags by name, listing all files that reference each flag, sorted alphabetically by flag name
+- DISC-3_AC-1 [ubiquitous]: The system SHALL aggregate discovered flags by name, listing all files that reference each flag, sorted alphabetically by flag name
 
 ### DISC-4: Template Source Resolution [MUST]
 
@@ -42,7 +42,7 @@ AS A developer, I WANT the features command to work with local and remote templa
 
 ACCEPTANCE CRITERIA
 
-- [x] DISC-4_AC-1 [ubiquitous]: The system SHALL resolve the template source using the same template resolver as the generate and diff commands, supporting local paths, Git repositories, and config defaults
+- DISC-4_AC-1 [ubiquitous]: The system SHALL resolve the template source using the same template resolver as the generate and diff commands, supporting local paths, Git repositories, and config defaults
 
 ### DISC-5: Configuration Integration [MUST]
 
@@ -50,7 +50,7 @@ AS A developer, I WANT the features command to use the same configuration loadin
 
 ACCEPTANCE CRITERIA
 
-- [x] DISC-5_AC-1 [ubiquitous]: The system SHALL load configuration via the config loader, using the template and refresh settings from config when not overridden by CLI options
+- DISC-5_AC-1 [ubiquitous]: The system SHALL load configuration via the config loader, using the template and refresh settings from config when not overridden by CLI options
 
 ### DISC-6: JSON Output [SHOULD]
 
@@ -58,7 +58,7 @@ AS A CI engineer, I WANT JSON output, SO THAT feature discovery results can be p
 
 ACCEPTANCE CRITERIA
 
-- [x] DISC-6_AC-1 [conditional]: IF `--json` is specified THEN the system SHALL output results as valid JSON to stdout containing the features array and files scanned count
+- DISC-6_AC-1 [conditional]: IF `--json` is specified THEN the system SHALL output results as valid JSON to stdout containing the features array and files scanned count
 
 ### DISC-7: Preset Display [SHOULD]
 
@@ -66,7 +66,7 @@ AS A developer, I WANT presets from `.awa.toml` shown alongside discovered flags
 
 ACCEPTANCE CRITERIA
 
-- [x] DISC-7_AC-1 [conditional]: IF preset definitions exist in the loaded config THEN the system SHALL include them in the output
+- DISC-7_AC-1 [conditional]: IF preset definitions exist in the loaded config THEN the system SHALL include them in the output
 
 ## Assumptions
 

--- a/.awa/specs/REQ-FP-feature-presets.md
+++ b/.awa/specs/REQ-FP-feature-presets.md
@@ -25,10 +25,10 @@ AS A developer, I WANT to define named feature presets in my config file, SO THA
 
 ACCEPTANCE CRITERIA
 
-- [ ] FP-1_AC-1 [ubiquitous]: The configuration file SHALL support a `[presets]` TOML table
-- [ ] FP-1_AC-2 [ubiquitous]: Each key in the `[presets]` table SHALL map to an array of feature strings
-- [ ] FP-1_AC-3 [event]: WHEN a preset value is not an array of strings THEN the system SHALL display a type error and exit
-- [ ] FP-1_AC-4 [conditional]: IF the `[presets]` table is absent THEN the system SHALL continue without error
+- FP-1_AC-1 [ubiquitous]: The configuration file SHALL support a `[presets]` TOML table
+- FP-1_AC-2 [ubiquitous]: Each key in the `[presets]` table SHALL map to an array of feature strings
+- FP-1_AC-3 [event]: WHEN a preset value is not an array of strings THEN the system SHALL display a type error and exit
+- FP-1_AC-4 [conditional]: IF the `[presets]` table is absent THEN the system SHALL continue without error
 
 ### FP-2: Preset CLI Option [MUST]
 
@@ -38,10 +38,10 @@ AS A developer, I WANT to activate presets from the command line, SO THAT I can 
 
 ACCEPTANCE CRITERIA
 
-- [ ] FP-2_AC-1 [ubiquitous]: The system SHALL accept `--preset <name>` as a CLI option
-- [ ] FP-2_AC-2 [event]: WHEN multiple `--preset` options are provided THEN the system SHALL collect all values
-- [ ] FP-2_AC-3 [event]: WHEN a preset name does not exist in config THEN the system SHALL display an error and exit
-- [ ] FP-2_AC-4 [conditional]: IF `--preset` is not provided THEN the system SHALL use an empty preset list as default
+- FP-2_AC-1 [ubiquitous]: The system SHALL accept `--preset <name>` as a CLI option
+- FP-2_AC-2 [event]: WHEN multiple `--preset` options are provided THEN the system SHALL collect all values
+- FP-2_AC-3 [event]: WHEN a preset name does not exist in config THEN the system SHALL display an error and exit
+- FP-2_AC-4 [conditional]: IF `--preset` is not provided THEN the system SHALL use an empty preset list as default
 
 ### FP-3: Preset Config Option [MUST]
 
@@ -51,9 +51,9 @@ AS A developer, I WANT to specify default presets in my config file, SO THAT I d
 
 ACCEPTANCE CRITERIA
 
-- [ ] FP-3_AC-1 [ubiquitous]: The configuration file SHALL support `preset` as an array of strings
-- [ ] FP-3_AC-2 [conditional]: IF CLI `--preset` is provided THEN it SHALL replace the config `preset` value
-- [ ] FP-3_AC-3 [conditional]: IF neither CLI nor config specifies presets THEN the system SHALL use an empty array
+- FP-3_AC-1 [ubiquitous]: The configuration file SHALL support `preset` as an array of strings
+- FP-3_AC-2 [conditional]: IF CLI `--preset` is provided THEN it SHALL replace the config `preset` value
+- FP-3_AC-3 [conditional]: IF neither CLI nor config specifies presets THEN the system SHALL use an empty array
 
 ### FP-4: Remove Features CLI Option [MUST]
 
@@ -63,11 +63,11 @@ AS A developer, I WANT to remove specific features from the final set, SO THAT I
 
 ACCEPTANCE CRITERIA
 
-- [ ] FP-4_AC-1 [ubiquitous]: The system SHALL accept `--remove-features <feature>` as a CLI option
-- [ ] FP-4_AC-2 [event]: WHEN multiple `--remove-features` options are provided THEN the system SHALL collect all values
-- [ ] FP-4_AC-3 [ubiquitous]: The system SHALL support comma-separated values in a single `--remove-features` option
-- [ ] FP-4_AC-4 [conditional]: IF a removed feature does not exist in the feature set THEN the system SHALL silently ignore it
-- [ ] FP-4_AC-5 [conditional]: IF `--remove-features` is not provided THEN the system SHALL use an empty removal list
+- FP-4_AC-1 [ubiquitous]: The system SHALL accept `--remove-features <feature>` as a CLI option
+- FP-4_AC-2 [event]: WHEN multiple `--remove-features` options are provided THEN the system SHALL collect all values
+- FP-4_AC-3 [ubiquitous]: The system SHALL support comma-separated values in a single `--remove-features` option
+- FP-4_AC-4 [conditional]: IF a removed feature does not exist in the feature set THEN the system SHALL silently ignore it
+- FP-4_AC-5 [conditional]: IF `--remove-features` is not provided THEN the system SHALL use an empty removal list
 
 ### FP-5: Remove Features Config Option [MUST]
 
@@ -77,9 +77,9 @@ AS A developer, I WANT to specify removed features in my config file, SO THAT I 
 
 ACCEPTANCE CRITERIA
 
-- [ ] FP-5_AC-1 [ubiquitous]: The configuration file SHALL support `remove-features` as an array of strings
-- [ ] FP-5_AC-2 [conditional]: IF CLI `--remove-features` is provided THEN it SHALL replace the config `remove-features` value
-- [ ] FP-5_AC-3 [conditional]: IF neither CLI nor config specifies removals THEN the system SHALL use an empty array
+- FP-5_AC-1 [ubiquitous]: The configuration file SHALL support `remove-features` as an array of strings
+- FP-5_AC-2 [conditional]: IF CLI `--remove-features` is provided THEN it SHALL replace the config `remove-features` value
+- FP-5_AC-3 [conditional]: IF neither CLI nor config specifies removals THEN the system SHALL use an empty array
 
 ### FP-6: Feature Resolution Order [MUST]
 
@@ -89,11 +89,11 @@ AS A developer, I WANT a predictable feature resolution order, SO THAT I can rea
 
 ACCEPTANCE CRITERIA
 
-- [ ] FP-6_AC-1 [ubiquitous]: The system SHALL compute base features as CLI `--features` if provided, else config `features`, else empty array
-- [ ] FP-6_AC-2 [ubiquitous]: The system SHALL compute preset features as the union of all features from activated presets
-- [ ] FP-6_AC-3 [ubiquitous]: The system SHALL compute the combined set as the union of base features and preset features
-- [ ] FP-6_AC-4 [ubiquitous]: The system SHALL compute the final features by removing all `remove-features` from the combined set
-- [ ] FP-6_AC-5 [ubiquitous]: The system SHALL deduplicate the final feature set
+- FP-6_AC-1 [ubiquitous]: The system SHALL compute base features as CLI `--features` if provided, else config `features`, else empty array
+- FP-6_AC-2 [ubiquitous]: The system SHALL compute preset features as the union of all features from activated presets
+- FP-6_AC-3 [ubiquitous]: The system SHALL compute the combined set as the union of base features and preset features
+- FP-6_AC-4 [ubiquitous]: The system SHALL compute the final features by removing all `remove-features` from the combined set
+- FP-6_AC-5 [ubiquitous]: The system SHALL deduplicate the final feature set
 
 ### FP-7: Preset Feature Union [MUST]
 
@@ -103,8 +103,8 @@ AS A developer, I WANT multiple presets to be merged, SO THAT I can combine pres
 
 ACCEPTANCE CRITERIA
 
-- [ ] FP-7_AC-1 [event]: WHEN multiple presets are activated THEN the system SHALL union their features
-- [ ] FP-7_AC-2 [ubiquitous]: Duplicate features across presets SHALL appear only once in the result
+- FP-7_AC-1 [event]: WHEN multiple presets are activated THEN the system SHALL union their features
+- FP-7_AC-2 [ubiquitous]: Duplicate features across presets SHALL appear only once in the result
 
 ## Assumptions
 

--- a/.awa/specs/REQ-GEN-generation.md
+++ b/.awa/specs/REQ-GEN-generation.md
@@ -26,9 +26,9 @@ AS A developer, I WANT output structure to match template structure, SO THAT fil
 
 ACCEPTANCE CRITERIA
 
-- [ ] GEN-1_AC-1 [ubiquitous]: The system SHALL recreate the template directory structure in the output directory
-- [ ] GEN-1_AC-2 [event]: WHEN a template is at `templates/.github/agents/foo.md` THEN the output SHALL be at `<output>/.github/agents/foo.md`
-- [ ] GEN-1_AC-3 [ubiquitous]: The system SHALL preserve directory nesting depth from templates
+- GEN-1_AC-1 [ubiquitous]: The system SHALL recreate the template directory structure in the output directory
+- GEN-1_AC-2 [event]: WHEN a template is at `templates/.github/agents/foo.md` THEN the output SHALL be at `<output>/.github/agents/foo.md`
+- GEN-1_AC-3 [ubiquitous]: The system SHALL preserve directory nesting depth from templates
 
 ### GEN-2: Automatic Directory Creation [MUST]
 
@@ -38,9 +38,9 @@ AS A developer, I WANT missing directories created automatically, SO THAT I don'
 
 ACCEPTANCE CRITERIA
 
-- [ ] GEN-2_AC-1 [conditional]: IF an output directory does not exist THEN the system SHALL create it recursively
-- [ ] GEN-2_AC-2 [event]: WHEN creating directories THEN the system SHALL create all intermediate directories as needed
-- [ ] GEN-2_AC-3 [event]: WHEN directory creation fails due to permissions THEN the system SHALL display an error and exit
+- GEN-2_AC-1 [conditional]: IF an output directory does not exist THEN the system SHALL create it recursively
+- GEN-2_AC-2 [event]: WHEN creating directories THEN the system SHALL create all intermediate directories as needed
+- GEN-2_AC-3 [event]: WHEN directory creation fails due to permissions THEN the system SHALL display an error and exit
 
 ### GEN-3: File Writing [MUST]
 
@@ -50,9 +50,9 @@ AS A developer, I WANT rendered templates written to files, SO THAT I have the g
 
 ACCEPTANCE CRITERIA
 
-- [ ] GEN-3_AC-1 [event]: WHEN a template renders non-empty content THEN the system SHALL write the content to the corresponding output file
-- [ ] GEN-3_AC-2 [ubiquitous]: The system SHALL write files with UTF-8 encoding
-- [ ] GEN-3_AC-3 [ubiquitous]: The system SHALL preserve the template filename as the output filename
+- GEN-3_AC-1 [event]: WHEN a template renders non-empty content THEN the system SHALL write the content to the corresponding output file
+- GEN-3_AC-2 [ubiquitous]: The system SHALL write files with UTF-8 encoding
+- GEN-3_AC-3 [ubiquitous]: The system SHALL preserve the template filename as the output filename
 
 ### GEN-4: Conflict Detection [MUST]
 
@@ -62,9 +62,9 @@ AS A developer, I WANT to know when files would be overwritten, SO THAT I don't 
 
 ACCEPTANCE CRITERIA
 
-- [ ] GEN-4_AC-1 [event]: WHEN an output file already exists THEN the system SHALL detect the conflict
-- [ ] GEN-4_AC-2 [conditional]: IF `--force` is not provided THEN the system SHALL handle the conflict via interactive prompt
-- [ ] GEN-4_AC-3 [conditional]: IF `--force` is provided THEN the system SHALL overwrite without prompting
+- GEN-4_AC-1 [event]: WHEN an output file already exists THEN the system SHALL detect the conflict
+- GEN-4_AC-2 [conditional]: IF `--force` is not provided THEN the system SHALL handle the conflict via interactive prompt
+- GEN-4_AC-3 [conditional]: IF `--force` is provided THEN the system SHALL overwrite without prompting
 
 ### GEN-5: Interactive Conflict Resolution [MUST]
 
@@ -74,13 +74,13 @@ AS A developer, I WANT to choose how to handle each conflict, SO THAT I have con
 
 ACCEPTANCE CRITERIA
 
-- [ ] GEN-5_AC-1 [event]: WHEN conflicts are detected AND `--force` is not provided THEN the system SHALL prompt the user once with all conflicts
-- [ ] GEN-5_AC-2 [ubiquitous]: The conflict prompt SHALL use a multi-select interface with checkboxes
-- [ ] GEN-5_AC-3 [event]: WHEN user checks a file THEN the system SHALL overwrite that file
-- [ ] GEN-5_AC-4 [event]: WHEN user unchecks a file THEN the system SHALL skip that file
-- [ ] GEN-5_AC-5 [ubiquitous]: The prompt SHALL display all conflicting file paths
-- [ ] GEN-5_AC-6 [ubiquitous]: All files SHALL be checked (selected for overwrite) by default
-- [ ] GEN-5_AC-7 [event]: WHEN existing file content matches new content THEN the system SHALL skip the file without prompting
+- GEN-5_AC-1 [event]: WHEN conflicts are detected AND `--force` is not provided THEN the system SHALL prompt the user once with all conflicts
+- GEN-5_AC-2 [ubiquitous]: The conflict prompt SHALL use a multi-select interface with checkboxes
+- GEN-5_AC-3 [event]: WHEN user checks a file THEN the system SHALL overwrite that file
+- GEN-5_AC-4 [event]: WHEN user unchecks a file THEN the system SHALL skip that file
+- GEN-5_AC-5 [ubiquitous]: The prompt SHALL display all conflicting file paths
+- GEN-5_AC-6 [ubiquitous]: All files SHALL be checked (selected for overwrite) by default
+- GEN-5_AC-7 [event]: WHEN existing file content matches new content THEN the system SHALL skip the file without prompting
 
 ### GEN-6: Dry Run Mode [MUST]
 
@@ -90,10 +90,10 @@ AS A developer, I WANT to preview generation without changes, SO THAT I can veri
 
 ACCEPTANCE CRITERIA
 
-- [ ] GEN-6_AC-1 [conditional]: IF `--dry-run` is provided THEN the system SHALL NOT write any files
-- [ ] GEN-6_AC-2 [conditional]: IF `--dry-run` is provided THEN the system SHALL NOT create any directories
-- [ ] GEN-6_AC-3 [conditional]: IF `--dry-run` is provided THEN the system SHALL NOT prompt for conflict resolution
-- [ ] GEN-6_AC-4 [conditional]: IF `--dry-run` is provided THEN the system SHALL display what actions would be taken
+- GEN-6_AC-1 [conditional]: IF `--dry-run` is provided THEN the system SHALL NOT write any files
+- GEN-6_AC-2 [conditional]: IF `--dry-run` is provided THEN the system SHALL NOT create any directories
+- GEN-6_AC-3 [conditional]: IF `--dry-run` is provided THEN the system SHALL NOT prompt for conflict resolution
+- GEN-6_AC-4 [conditional]: IF `--dry-run` is provided THEN the system SHALL display what actions would be taken
 
 ### GEN-7: Dry Run Output [MUST]
 
@@ -103,10 +103,10 @@ AS A developer, I WANT clear dry-run output, SO THAT I understand what would hap
 
 ACCEPTANCE CRITERIA
 
-- [ ] GEN-7_AC-1 [conditional]: IF `--dry-run` is provided THEN the system SHALL list files that would be created
-- [ ] GEN-7_AC-2 [conditional]: IF `--dry-run` is provided THEN the system SHALL list files that would be skipped (empty output)
-- [ ] GEN-7_AC-3 [conditional]: IF `--dry-run` is provided THEN the system SHALL list files that would conflict
-- [ ] GEN-7_AC-4 [conditional]: IF `--dry-run` is provided THEN the system SHALL indicate the action that would be taken for each file
+- GEN-7_AC-1 [conditional]: IF `--dry-run` is provided THEN the system SHALL list files that would be created
+- GEN-7_AC-2 [conditional]: IF `--dry-run` is provided THEN the system SHALL list files that would be skipped (empty output)
+- GEN-7_AC-3 [conditional]: IF `--dry-run` is provided THEN the system SHALL list files that would conflict
+- GEN-7_AC-4 [conditional]: IF `--dry-run` is provided THEN the system SHALL indicate the action that would be taken for each file
 
 ### GEN-8: Underscore Prefix Exclusion [MUST]
 
@@ -116,9 +116,9 @@ AS A developer, I WANT files starting with underscore excluded, SO THAT helper f
 
 ACCEPTANCE CRITERIA
 
-- [ ] GEN-8_AC-1 [ubiquitous]: The system SHALL NOT output files whose names start with `_`
-- [ ] GEN-8_AC-2 [ubiquitous]: The system SHALL NOT output directories whose names start with `_`
-- [ ] GEN-8_AC-3 [ubiquitous]: The system SHALL NOT traverse into directories whose names start with `_`
+- GEN-8_AC-1 [ubiquitous]: The system SHALL NOT output files whose names start with `_`
+- GEN-8_AC-2 [ubiquitous]: The system SHALL NOT output directories whose names start with `_`
+- GEN-8_AC-3 [ubiquitous]: The system SHALL NOT traverse into directories whose names start with `_`
 
 ### GEN-9: Generation Summary [SHOULD]
 
@@ -128,14 +128,14 @@ AS A developer, I WANT a summary after generation, SO THAT I know what was done.
 
 ACCEPTANCE CRITERIA
 
-- [ ] GEN-9_AC-1 [event]: WHEN generation completes THEN the system SHOULD display a summary
-- [ ] GEN-9_AC-2 [ubiquitous]: The summary SHOULD include count of files created
-- [ ] GEN-9_AC-3 [ubiquitous]: The summary SHOULD include count of files skipped
-- [ ] GEN-9_AC-4 [ubiquitous]: The summary SHOULD include count of files overwritten
-- [ ] GEN-9_AC-5 [conditional]: IF conflicts were skipped by user choice THEN the summary SHOULD include count of user-skipped files
-- [ ] GEN-9_AC-6 [conditional]: IF no files were created or overwritten THEN the system SHOULD display a warning message indicating no files were written
-- [ ] GEN-9_AC-7 [conditional]: IF files were deleted THEN the summary SHOULD include count of deleted files
-- [ ] GEN-9_AC-8 [conditional]: IF files were skipped due to identical content THEN the summary SHOULD include count of equal-skipped files
+- GEN-9_AC-1 [event]: WHEN generation completes THEN the system SHOULD display a summary
+- GEN-9_AC-2 [ubiquitous]: The summary SHOULD include count of files created
+- GEN-9_AC-3 [ubiquitous]: The summary SHOULD include count of files skipped
+- GEN-9_AC-4 [ubiquitous]: The summary SHOULD include count of files overwritten
+- GEN-9_AC-5 [conditional]: IF conflicts were skipped by user choice THEN the summary SHOULD include count of user-skipped files
+- GEN-9_AC-6 [conditional]: IF no files were created or overwritten THEN the system SHOULD display a warning message indicating no files were written
+- GEN-9_AC-7 [conditional]: IF files were deleted THEN the summary SHOULD include count of deleted files
+- GEN-9_AC-8 [conditional]: IF files were skipped due to identical content THEN the summary SHOULD include count of equal-skipped files
 
 ### GEN-10: Exit Codes [MUST]
 
@@ -145,9 +145,9 @@ AS A CI system, I WANT meaningful exit codes, SO THAT I can detect success or fa
 
 ACCEPTANCE CRITERIA
 
-- [ ] GEN-10_AC-1 [event]: WHEN generation completes successfully THEN the system SHALL exit with code 0
-- [ ] GEN-10_AC-2 [event]: WHEN generation fails due to error THEN the system SHALL exit with a non-zero code
-- [ ] GEN-10_AC-3 [event]: WHEN user cancels during prompt THEN the system SHALL exit with a non-zero code
+- GEN-10_AC-1 [event]: WHEN generation completes successfully THEN the system SHALL exit with code 0
+- GEN-10_AC-2 [event]: WHEN generation fails due to error THEN the system SHALL exit with a non-zero code
+- GEN-10_AC-3 [event]: WHEN user cancels during prompt THEN the system SHALL exit with a non-zero code
 
 ### GEN-11: Error Handling [MUST]
 
@@ -157,10 +157,10 @@ AS A developer, I WANT clear error messages, SO THAT I can diagnose and fix prob
 
 ACCEPTANCE CRITERIA
 
-- [ ] GEN-11_AC-1 [event]: WHEN file writing fails THEN the system SHALL display an error with the file path and reason
-- [ ] GEN-11_AC-2 [event]: WHEN template rendering fails THEN the system SHALL display an error with the template path and reason
-- [ ] GEN-11_AC-3 [event]: WHEN an error occurs THEN the system SHALL stop generation for remaining files
-- [ ] GEN-11_AC-4 [ubiquitous]: Error messages SHALL be written to stderr
+- GEN-11_AC-1 [event]: WHEN file writing fails THEN the system SHALL display an error with the file path and reason
+- GEN-11_AC-2 [event]: WHEN template rendering fails THEN the system SHALL display an error with the template path and reason
+- GEN-11_AC-3 [event]: WHEN an error occurs THEN the system SHALL stop generation for remaining files
+- GEN-11_AC-4 [ubiquitous]: Error messages SHALL be written to stderr
 
 ### GEN-12: Delete List Processing [MUST]
 
@@ -170,14 +170,14 @@ AS A developer, I WANT stale files from previous template versions cleaned up, S
 
 ACCEPTANCE CRITERIA
 
-- [ ] GEN-12_AC-1 [conditional]: IF `_delete.txt` exists in the template root THEN the system SHALL parse it for delete candidates
-- [ ] GEN-12_AC-2 [conditional]: IF `--delete` is not provided THEN the system SHALL warn about eligible files without deleting them
-- [ ] GEN-12_AC-3 [conditional]: IF `--delete` is provided THEN the system SHALL prompt the user to confirm deletions
-- [ ] GEN-12_AC-4 [conditional]: IF `--delete` AND `--force` are provided THEN the system SHALL delete without prompting
-- [ ] GEN-12_AC-5 [conditional]: IF `--delete` AND `--dry-run` are provided THEN the system SHALL log deletions without executing them
-- [ ] GEN-12_AC-6 [conditional]: IF a delete list entry conflicts with a generated file THEN the system SHALL skip the deletion with a warning
-- [ ] GEN-12_AC-7 [conditional]: IF a delete list entry does not exist in the output directory THEN the system SHALL silently skip it
-- [ ] GEN-12_AC-8 [ubiquitous]: Delete list entries SHALL support feature-gated sections (`# @feature <name>`) where paths are deleted only when NONE of the listed features are active
+- GEN-12_AC-1 [conditional]: IF `_delete.txt` exists in the template root THEN the system SHALL parse it for delete candidates
+- GEN-12_AC-2 [conditional]: IF `--delete` is not provided THEN the system SHALL warn about eligible files without deleting them
+- GEN-12_AC-3 [conditional]: IF `--delete` is provided THEN the system SHALL prompt the user to confirm deletions
+- GEN-12_AC-4 [conditional]: IF `--delete` AND `--force` are provided THEN the system SHALL delete without prompting
+- GEN-12_AC-5 [conditional]: IF `--delete` AND `--dry-run` are provided THEN the system SHALL log deletions without executing them
+- GEN-12_AC-6 [conditional]: IF a delete list entry conflicts with a generated file THEN the system SHALL skip the deletion with a warning
+- GEN-12_AC-7 [conditional]: IF a delete list entry does not exist in the output directory THEN the system SHALL silently skip it
+- GEN-12_AC-8 [ubiquitous]: Delete list entries SHALL support feature-gated sections (`# @feature <name>`) where paths are deleted only when NONE of the listed features are active
 
 DEPENDS ON: CLI-12
 

--- a/.awa/specs/REQ-INIT-init-alias.md
+++ b/.awa/specs/REQ-INIT-init-alias.md
@@ -24,7 +24,7 @@ AS A developer, I WANT to run `awa init` as an alternative to `awa generate`, SO
 
 ACCEPTANCE CRITERIA
 
-- [ ] INIT-1_AC-1 [ubiquitous]: The system SHALL register `init` as an alias for the `generate` command
+- INIT-1_AC-1 [ubiquitous]: The system SHALL register `init` as an alias for the `generate` command
 
 ### INIT-2: Option Parity [MUST]
 
@@ -34,7 +34,7 @@ AS A developer, I WANT `awa init` to accept all options that `awa generate` acce
 
 ACCEPTANCE CRITERIA
 
-- [ ] INIT-2_AC-1 [ubiquitous]: The `init` alias SHALL accept all options defined on the `generate` command
+- INIT-2_AC-1 [ubiquitous]: The `init` alias SHALL accept all options defined on the `generate` command
 
 ### INIT-3: Behavioural Identity [MUST]
 
@@ -44,7 +44,7 @@ AS A developer, I WANT `awa init <args>` to produce the same result as `awa gene
 
 ACCEPTANCE CRITERIA
 
-- [ ] INIT-3_AC-1 [ubiquitous]: `awa init <args>` SHALL produce output identical to `awa generate <args>` for the same arguments
+- INIT-3_AC-1 [ubiquitous]: `awa init <args>` SHALL produce output identical to `awa generate <args>` for the same arguments
 
 ### INIT-4: Help Visibility [MUST]
 
@@ -54,7 +54,7 @@ AS A developer, I WANT both `init` and `generate` to appear in help output, SO T
 
 ACCEPTANCE CRITERIA
 
-- [ ] INIT-4_AC-1 [event]: WHEN the user invokes `awa --help` THEN the help output SHALL list both `generate` and `init`
+- INIT-4_AC-1 [event]: WHEN the user invokes `awa --help` THEN the help output SHALL list both `generate` and `init`
 
 ### INIT-5: Config-Not-Found Hint [SHOULD]
 
@@ -64,7 +64,7 @@ AS A developer, I WANT an informational hint when no config file is found, SO TH
 
 ACCEPTANCE CRITERIA
 
-- [ ] INIT-5_AC-1 [conditional]: IF no `.awa.toml` is found AND `--config` was not provided THEN the system SHALL log an info-level hint suggesting config file creation
+- INIT-5_AC-1 [conditional]: IF no `.awa.toml` is found AND `--config` was not provided THEN the system SHALL log an info-level hint suggesting config file creation
 
 ## Assumptions
 

--- a/.awa/specs/REQ-JSON-json-output.md
+++ b/.awa/specs/REQ-JSON-json-output.md
@@ -22,7 +22,7 @@ AS A CI system, I WANT the generate command to support a --json flag, SO THAT I 
 
 ACCEPTANCE CRITERIA
 
-- [ ] JSON-1_AC-1 [event]: WHEN the --json flag is provided to the generate command THEN the system SHALL output a valid JSON object to stdout containing the generation result
+- JSON-1_AC-1 [event]: WHEN the --json flag is provided to the generate command THEN the system SHALL output a valid JSON object to stdout containing the generation result
 
 ### JSON-2: Diff JSON Output [MUST]
 
@@ -30,7 +30,7 @@ AS A CI system, I WANT the diff command to support a --json flag, SO THAT I can 
 
 ACCEPTANCE CRITERIA
 
-- [ ] JSON-2_AC-1 [event]: WHEN the --json flag is provided to the diff command THEN the system SHALL output a valid JSON object to stdout containing the diff result
+- JSON-2_AC-1 [event]: WHEN the --json flag is provided to the diff command THEN the system SHALL output a valid JSON object to stdout containing the diff result
 
 ### JSON-3: Generate JSON Structure [MUST]
 
@@ -38,7 +38,7 @@ AS A CI system, I WANT the generate JSON output to include actions and counts, S
 
 ACCEPTANCE CRITERIA
 
-- [ ] JSON-3_AC-1 [conditional]: IF --json is provided to generate THEN the JSON output SHALL contain an actions array with type and path per entry, and a counts object with created, overwritten, skipped, and deleted fields
+- JSON-3_AC-1 [conditional]: IF --json is provided to generate THEN the JSON output SHALL contain an actions array with type and path per entry, and a counts object with created, overwritten, skipped, and deleted fields
 
 ### JSON-4: Diff JSON Structure [MUST]
 
@@ -46,7 +46,7 @@ AS A CI system, I WANT the diff JSON output to include diffs and counts, SO THAT
 
 ACCEPTANCE CRITERIA
 
-- [ ] JSON-4_AC-1 [conditional]: IF --json is provided to diff THEN the JSON output SHALL contain a diffs array with path, status, and optional diff per entry, and a counts object with changed, new, matching, and deleted fields
+- JSON-4_AC-1 [conditional]: IF --json is provided to diff THEN the JSON output SHALL contain a diffs array with path, status, and optional diff per entry, and a counts object with changed, new, matching, and deleted fields
 
 ### JSON-5: Summary Output [SHOULD]
 
@@ -54,7 +54,7 @@ AS A developer, I WANT a --summary flag for compact output, SO THAT I can see co
 
 ACCEPTANCE CRITERIA
 
-- [ ] JSON-5_AC-1 [event]: WHEN the --summary flag is provided THEN the system SHALL output a single line with counts only
+- JSON-5_AC-1 [event]: WHEN the --summary flag is provided THEN the system SHALL output a single line with counts only
 
 ### JSON-6: Suppress Interactive Output [MUST]
 
@@ -62,7 +62,7 @@ AS A CI system, I WANT --json to suppress all non-JSON output, SO THAT stdout co
 
 ACCEPTANCE CRITERIA
 
-- [ ] JSON-6_AC-1 [conditional]: IF --json is active THEN the system SHALL suppress all interactive prompts, spinners, intro and outro messages, and logger output to stdout
+- JSON-6_AC-1 [conditional]: IF --json is active THEN the system SHALL suppress all interactive prompts, spinners, intro and outro messages, and logger output to stdout
 
 ### JSON-7: JSON Implies Dry-Run [MUST]
 
@@ -70,7 +70,7 @@ AS A CI system, I WANT --json to imply --dry-run for generate, SO THAT JSON outp
 
 ACCEPTANCE CRITERIA
 
-- [ ] JSON-7_AC-1 [conditional]: IF --json is provided to the generate command THEN the system SHALL enforce dry-run mode regardless of the --dry-run flag value
+- JSON-7_AC-1 [conditional]: IF --json is provided to the generate command THEN the system SHALL enforce dry-run mode regardless of the --dry-run flag value
 
 ### JSON-8: Output Routing [MUST]
 
@@ -78,7 +78,7 @@ AS A CI system, I WANT JSON on stdout and errors on stderr, SO THAT I can captur
 
 ACCEPTANCE CRITERIA
 
-- [ ] JSON-8_AC-1 [ubiquitous]: The system SHALL write JSON output to stdout and error messages to stderr when --json is active
+- JSON-8_AC-1 [ubiquitous]: The system SHALL write JSON output to stdout and error messages to stderr when --json is active
 
 ## Assumptions
 

--- a/.awa/specs/REQ-MULTI-multi-target.md
+++ b/.awa/specs/REQ-MULTI-multi-target.md
@@ -25,7 +25,7 @@ AS A developer, I WANT to define `[targets.<name>]` sections in `.awa.toml`, SO 
 
 ACCEPTANCE CRITERIA
 
-- [ ] MULTI-1_AC-1 [ubiquitous]: The configuration file SHALL support `[targets.<name>]` sections as TOML tables
+- MULTI-1_AC-1 [ubiquitous]: The configuration file SHALL support `[targets.<name>]` sections as TOML tables
 
 ### MULTI-2: Target Section Fields [MUST]
 
@@ -35,7 +35,7 @@ AS A developer, I WANT each target section to specify output, features, preset, 
 
 ACCEPTANCE CRITERIA
 
-- [ ] MULTI-2_AC-1 [ubiquitous]: Each target section SHALL support `output`, `features`, `preset`, `remove-features`, and `template` fields (all optional; inherit from root)
+- MULTI-2_AC-1 [ubiquitous]: Each target section SHALL support `output`, `features`, `preset`, `remove-features`, and `template` fields (all optional; inherit from root)
 
 ### MULTI-3: Target Inheritance [MUST]
 
@@ -45,7 +45,7 @@ AS A developer, I WANT target sections to inherit from root config, SO THAT I on
 
 ACCEPTANCE CRITERIA
 
-- [ ] MULTI-3_AC-1 [ubiquitous]: Target sections SHALL inherit from root config via nullish coalescing (target values override root)
+- MULTI-3_AC-1 [ubiquitous]: Target sections SHALL inherit from root config via nullish coalescing (target values override root)
 
 ### MULTI-4: Generate All Targets [MUST]
 
@@ -55,8 +55,8 @@ AS A developer, I WANT `awa generate --all` to process all named targets, SO THA
 
 ACCEPTANCE CRITERIA
 
-- [ ] MULTI-4_AC-1 [event]: WHEN `--all` is provided THEN the system SHALL process all named `[targets.*]` sections
-- [ ] MULTI-4_AC-2 [event]: WHEN `--all` is provided AND no `[targets.*]` sections exist THEN the system SHALL error with `NO_TARGETS`
+- MULTI-4_AC-1 [event]: WHEN `--all` is provided THEN the system SHALL process all named `[targets.*]` sections
+- MULTI-4_AC-2 [event]: WHEN `--all` is provided AND no `[targets.*]` sections exist THEN the system SHALL error with `NO_TARGETS`
 
 ### MULTI-5: Generate Single Target [MUST]
 
@@ -66,8 +66,8 @@ AS A developer, I WANT `awa generate --target <name>` to process a specific targ
 
 ACCEPTANCE CRITERIA
 
-- [ ] MULTI-5_AC-1 [event]: WHEN `--target <name>` is provided THEN the system SHALL process only the named target
-- [ ] MULTI-5_AC-2 [event]: WHEN `--target <name>` is provided AND the name doesn't exist THEN the system SHALL error with `UNKNOWN_TARGET`
+- MULTI-5_AC-1 [event]: WHEN `--target <name>` is provided THEN the system SHALL process only the named target
+- MULTI-5_AC-2 [event]: WHEN `--target <name>` is provided AND the name doesn't exist THEN the system SHALL error with `UNKNOWN_TARGET`
 
 ### MULTI-6: Diff All Targets [MUST]
 
@@ -77,7 +77,7 @@ AS A developer, I WANT `awa diff --all` and `awa diff --target` to work identica
 
 ACCEPTANCE CRITERIA
 
-- [ ] MULTI-6_AC-1 [ubiquitous]: The diff command SHALL support `--all` and `--target` identically to the generate command
+- MULTI-6_AC-1 [ubiquitous]: The diff command SHALL support `--all` and `--target` identically to the generate command
 
 ### MULTI-7: Backward Compatibility [MUST]
 
@@ -87,7 +87,7 @@ AS A developer, I WANT existing behavior unchanged when no `--all` or `--target`
 
 ACCEPTANCE CRITERIA
 
-- [ ] MULTI-7_AC-1 [conditional]: IF neither `--all` nor `--target` is provided THEN the system SHALL use existing single-target behavior
+- MULTI-7_AC-1 [conditional]: IF neither `--all` nor `--target` is provided THEN the system SHALL use existing single-target behavior
 
 ### MULTI-8: Per-Target Reporting [MUST]
 
@@ -97,7 +97,7 @@ AS A developer, I WANT results reported per target with clear labels, SO THAT I 
 
 ACCEPTANCE CRITERIA
 
-- [ ] MULTI-8_AC-1 [ubiquitous]: Batch mode output SHALL prefix log lines with `[target-name]`
+- MULTI-8_AC-1 [ubiquitous]: Batch mode output SHALL prefix log lines with `[target-name]`
 
 ### MULTI-9: Missing Output Error [MUST]
 
@@ -107,7 +107,7 @@ AS A developer, I WANT a clear error naming the target when output is unresolvab
 
 ACCEPTANCE CRITERIA
 
-- [ ] MULTI-9_AC-1 [event]: WHEN a target has no output AND root has no output THEN the system SHALL error with `MISSING_OUTPUT` naming the target
+- MULTI-9_AC-1 [event]: WHEN a target has no output AND root has no output THEN the system SHALL error with `MISSING_OUTPUT` naming the target
 
 ### MULTI-10: Non-Interactive Batch Mode [MUST]
 
@@ -117,7 +117,7 @@ AS A developer, I WANT `--all` and `--target` to suppress interactive prompting,
 
 ACCEPTANCE CRITERIA
 
-- [ ] MULTI-10_AC-1 [conditional]: IF `--all` or `--target` is set THEN the system SHALL NOT prompt for tool feature selection
+- MULTI-10_AC-1 [conditional]: IF `--all` or `--target` is set THEN the system SHALL NOT prompt for tool feature selection
 
 ### MULTI-11: CLI Output Override [MUST]
 
@@ -127,7 +127,7 @@ AS A developer, I WANT consistent CLI positional behavior with batch flags, SO T
 
 ACCEPTANCE CRITERIA
 
-- [ ] MULTI-11_AC-1 [conditional]: IF `--all` is set THEN CLI positional `[output]` SHALL be ignored; IF `--target` is set THEN CLI positional SHALL override the target's output
+- MULTI-11_AC-1 [conditional]: IF `--all` is set THEN CLI positional `[output]` SHALL be ignored; IF `--target` is set THEN CLI positional SHALL override the target's output
 
 ### MULTI-12: Diff Exit Code Aggregation [MUST]
 
@@ -137,7 +137,7 @@ AS A developer, I WANT `diff --all` to return an aggregated exit code, SO THAT C
 
 ACCEPTANCE CRITERIA
 
-- [ ] MULTI-12_AC-1 [ubiquitous]: `diff --all` exit code SHALL be `1` if any target has differences, `0` if all identical, `2` on error
+- MULTI-12_AC-1 [ubiquitous]: `diff --all` exit code SHALL be `1` if any target has differences, `0` if all identical, `2` on error
 
 ## Assumptions
 

--- a/.awa/specs/REQ-OVL-overlays.md
+++ b/.awa/specs/REQ-OVL-overlays.md
@@ -28,7 +28,7 @@ AS A CLI user, I WANT to supply one or more --overlay paths on the generate comm
 
 ACCEPTANCE CRITERIA
 
-- [ ] OVL-1_AC-1 [event]: WHEN `--overlay <path>` is provided one or more times on the generate command THEN the system SHALL include each path as an overlay source applied over the base template
+- OVL-1_AC-1 [event]: WHEN `--overlay <path>` is provided one or more times on the generate command THEN the system SHALL include each path as an overlay source applied over the base template
 
 DEPENDS ON: (none)
 
@@ -38,7 +38,7 @@ AS A CLI user, I WANT an overlay file at the same relative path as a base file t
 
 ACCEPTANCE CRITERIA
 
-- [ ] OVL-2_AC-1 [ubiquitous]: The system SHALL replace a base template file with any overlay file that shares the same relative path in the merged view
+- OVL-2_AC-1 [ubiquitous]: The system SHALL replace a base template file with any overlay file that shares the same relative path in the merged view
 
 DEPENDS ON: OVL-1
 
@@ -48,7 +48,7 @@ AS A CLI user, I WANT base template files that have no overlay counterpart to ap
 
 ACCEPTANCE CRITERIA
 
-- [ ] OVL-3_AC-1 [ubiquitous]: The system SHALL include every base template file that is not present in any overlay unchanged in the merged view
+- OVL-3_AC-1 [ubiquitous]: The system SHALL include every base template file that is not present in any overlay unchanged in the merged view
 
 DEPENDS ON: OVL-1
 
@@ -58,7 +58,7 @@ AS A CLI user, I WANT overlay files that do not exist in the base template to be
 
 ACCEPTANCE CRITERIA
 
-- [ ] OVL-4_AC-1 [ubiquitous]: The system SHALL include every overlay file that has no corresponding base template file in the merged view
+- OVL-4_AC-1 [ubiquitous]: The system SHALL include every overlay file that has no corresponding base template file in the merged view
 
 DEPENDS ON: OVL-1
 
@@ -68,7 +68,7 @@ AS A CLI user, I WANT multiple overlays to be applied in the order I specify the
 
 ACCEPTANCE CRITERIA
 
-- [ ] OVL-5_AC-1 [ubiquitous]: The system SHALL apply multiple overlays in the order specified, with each subsequent overlay's files overriding any file from an earlier overlay at the same relative path
+- OVL-5_AC-1 [ubiquitous]: The system SHALL apply multiple overlays in the order specified, with each subsequent overlay's files overriding any file from an earlier overlay at the same relative path
 
 DEPENDS ON: OVL-1
 
@@ -78,7 +78,7 @@ AS A CLI user, I WANT to specify overlays as either local directory paths or Git
 
 ACCEPTANCE CRITERIA
 
-- [ ] OVL-6_AC-1 [ubiquitous]: The system SHALL resolve overlay sources using the same local-path and Git-repository resolution logic used for the main template source
+- OVL-6_AC-1 [ubiquitous]: The system SHALL resolve overlay sources using the same local-path and Git-repository resolution logic used for the main template source
 
 DEPENDS ON: OVL-1
 
@@ -88,7 +88,7 @@ AS A CLI user, I WANT the diff command to accept --overlay options identical to 
 
 ACCEPTANCE CRITERIA
 
-- [ ] OVL-7_AC-1 [event]: WHEN `--overlay <path>` is provided on the diff command THEN the system SHALL compare the merged template view against the target directory
+- OVL-7_AC-1 [event]: WHEN `--overlay <path>` is provided on the diff command THEN the system SHALL compare the merged template view against the target directory
 
 DEPENDS ON: OVL-2
 
@@ -98,7 +98,7 @@ AS A project maintainer, I WANT to declare an `overlay` array in `.awa.toml`, SO
 
 ACCEPTANCE CRITERIA
 
-- [ ] OVL-8_AC-1 [event]: WHEN `overlay` is declared as an array of strings in `.awa.toml` THEN the system SHALL use those paths as overlay sources for generate and diff commands
+- OVL-8_AC-1 [event]: WHEN `overlay` is declared as an array of strings in `.awa.toml` THEN the system SHALL use those paths as overlay sources for generate and diff commands
 
 DEPENDS ON: OVL-1
 

--- a/.awa/specs/REQ-TPL-templates.md
+++ b/.awa/specs/REQ-TPL-templates.md
@@ -27,10 +27,10 @@ AS A developer, I WANT to use local template directories, SO THAT I can develop 
 
 ACCEPTANCE CRITERIA
 
-- [ ] TPL-1_AC-1 [event]: WHEN `--template` specifies a relative path THEN the system SHALL resolve it relative to the current directory
-- [ ] TPL-1_AC-2 [event]: WHEN `--template` specifies an absolute path THEN the system SHALL use it directly
-- [ ] TPL-1_AC-3 [event]: WHEN the local template path does not exist THEN the system SHALL display an error and exit
-- [ ] TPL-1_AC-4 [ubiquitous]: The system SHALL NOT cache local template sources
+- TPL-1_AC-1 [event]: WHEN `--template` specifies a relative path THEN the system SHALL resolve it relative to the current directory
+- TPL-1_AC-2 [event]: WHEN `--template` specifies an absolute path THEN the system SHALL use it directly
+- TPL-1_AC-3 [event]: WHEN the local template path does not exist THEN the system SHALL display an error and exit
+- TPL-1_AC-4 [ubiquitous]: The system SHALL NOT cache local template sources
 
 ### TPL-2: Git Repository Template Source [MUST]
 
@@ -40,12 +40,12 @@ AS A developer, I WANT to use templates from Git repositories, SO THAT I can sha
 
 ACCEPTANCE CRITERIA
 
-- [ ] TPL-2_AC-1 [ubiquitous]: The system SHALL support GitHub shorthand format `owner/repo`
-- [ ] TPL-2_AC-2 [ubiquitous]: The system SHALL support prefixed formats `github:owner/repo`, `gitlab:owner/repo`, `bitbucket:owner/repo`
-- [ ] TPL-2_AC-3 [ubiquitous]: The system SHALL support full HTTPS URLs `https://github.com/owner/repo`
-- [ ] TPL-2_AC-4 [ubiquitous]: The system SHALL support SSH URLs `git@github.com:owner/repo`
-- [ ] TPL-2_AC-5 [ubiquitous]: The system SHALL support subdirectory paths `owner/repo/path/to/templates`
-- [ ] TPL-2_AC-6 [ubiquitous]: The system SHALL support ref specifiers `owner/repo#branch`, `owner/repo#tag`, `owner/repo#commit`
+- TPL-2_AC-1 [ubiquitous]: The system SHALL support GitHub shorthand format `owner/repo`
+- TPL-2_AC-2 [ubiquitous]: The system SHALL support prefixed formats `github:owner/repo`, `gitlab:owner/repo`, `bitbucket:owner/repo`
+- TPL-2_AC-3 [ubiquitous]: The system SHALL support full HTTPS URLs `https://github.com/owner/repo`
+- TPL-2_AC-4 [ubiquitous]: The system SHALL support SSH URLs `git@github.com:owner/repo`
+- TPL-2_AC-5 [ubiquitous]: The system SHALL support subdirectory paths `owner/repo/path/to/templates`
+- TPL-2_AC-6 [ubiquitous]: The system SHALL support ref specifiers `owner/repo#branch`, `owner/repo#tag`, `owner/repo#commit`
 
 ### TPL-3: Template Caching [MUST]
 
@@ -55,10 +55,10 @@ AS A developer, I WANT Git templates cached locally, SO THAT repeated runs don't
 
 ACCEPTANCE CRITERIA
 
-- [ ] TPL-3_AC-1 [ubiquitous]: The system SHALL cache Git templates in `~/.cache/awa/templates/`
-- [ ] TPL-3_AC-2 [conditional]: IF a cached version exists AND `--refresh` is not provided THEN the system SHALL use the cached version
-- [ ] TPL-3_AC-3 [conditional]: IF `--refresh` is provided THEN the system SHALL re-fetch the Git template
-- [ ] TPL-3_AC-4 [event]: WHEN fetching a Git template THEN the system SHALL perform a shallow fetch without `.git` directory
+- TPL-3_AC-1 [ubiquitous]: The system SHALL cache Git templates in `~/.cache/awa/templates/`
+- TPL-3_AC-2 [conditional]: IF a cached version exists AND `--refresh` is not provided THEN the system SHALL use the cached version
+- TPL-3_AC-3 [conditional]: IF `--refresh` is provided THEN the system SHALL re-fetch the Git template
+- TPL-3_AC-4 [event]: WHEN fetching a Git template THEN the system SHALL perform a shallow fetch without `.git` directory
 
 ### TPL-4: Template Rendering [MUST]
 
@@ -68,10 +68,10 @@ AS A template author, I WANT Eta template syntax, SO THAT I can create dynamic t
 
 ACCEPTANCE CRITERIA
 
-- [ ] TPL-4_AC-1 [ubiquitous]: The system SHALL render templates using Eta syntax
-- [ ] TPL-4_AC-2 [ubiquitous]: The system SHALL support output tags `<%= expression %>`
-- [ ] TPL-4_AC-3 [ubiquitous]: The system SHALL support control flow tags `<% code %>`
-- [ ] TPL-4_AC-4 [ubiquitous]: The system SHALL support raw output tags `<%~ expression %>`
+- TPL-4_AC-1 [ubiquitous]: The system SHALL render templates using Eta syntax
+- TPL-4_AC-2 [ubiquitous]: The system SHALL support output tags `<%= expression %>`
+- TPL-4_AC-3 [ubiquitous]: The system SHALL support control flow tags `<% code %>`
+- TPL-4_AC-4 [ubiquitous]: The system SHALL support raw output tags `<%~ expression %>`
 
 ### TPL-5: Feature Flag Context [MUST]
 
@@ -81,9 +81,9 @@ AS A template author, I WANT access to feature flags in templates, SO THAT I can
 
 ACCEPTANCE CRITERIA
 
-- [ ] TPL-5_AC-1 [ubiquitous]: The system SHALL provide feature flags as `it.features` array in template context
-- [ ] TPL-5_AC-2 [ubiquitous]: The `it.features` array SHALL contain all feature flag strings passed via CLI or config
-- [ ] TPL-5_AC-3 [state]: WHEN no features are provided THEN `it.features` SHALL be an empty array
+- TPL-5_AC-1 [ubiquitous]: The system SHALL provide feature flags as `it.features` array in template context
+- TPL-5_AC-2 [ubiquitous]: The `it.features` array SHALL contain all feature flag strings passed via CLI or config
+- TPL-5_AC-3 [state]: WHEN no features are provided THEN `it.features` SHALL be an empty array
 
 ### TPL-6: Conditional Template Logic [MUST]
 
@@ -93,8 +93,8 @@ AS A template author, I WANT to check for feature flags, SO THAT I can include c
 
 ACCEPTANCE CRITERIA
 
-- [ ] TPL-6_AC-1 [ubiquitous]: Templates SHALL support checking features via `it.features.includes('feature-name')`
-- [ ] TPL-6_AC-2 [event]: WHEN a feature check evaluates to false THEN the conditional content SHALL be excluded from output
+- TPL-6_AC-1 [ubiquitous]: Templates SHALL support checking features via `it.features.includes('feature-name')`
+- TPL-6_AC-2 [event]: WHEN a feature check evaluates to false THEN the conditional content SHALL be excluded from output
 
 ### TPL-7: Empty Output Handling [MUST]
 
@@ -104,9 +104,9 @@ AS A template author, I WANT empty output to skip file creation, SO THAT optiona
 
 ACCEPTANCE CRITERIA
 
-- [ ] TPL-7_AC-1 [conditional]: IF rendered template output is empty or whitespace-only THEN the system SHALL NOT create the output file
-- [ ] TPL-7_AC-2 [conditional]: IF rendered template contains only `<!-- AWA:EMPTY_FILE -->` marker THEN the system SHALL create an empty file
-- [ ] TPL-7_AC-3 [event]: WHEN empty output causes file skip THEN the system SHALL log that the file was skipped
+- TPL-7_AC-1 [conditional]: IF rendered template output is empty or whitespace-only THEN the system SHALL NOT create the output file
+- TPL-7_AC-2 [conditional]: IF rendered template contains only `<!-- AWA:EMPTY_FILE -->` marker THEN the system SHALL create an empty file
+- TPL-7_AC-3 [event]: WHEN empty output causes file skip THEN the system SHALL log that the file was skipped
 
 ### TPL-8: Partial Templates [MUST]
 
@@ -116,10 +116,10 @@ AS A template author, I WANT reusable partial templates, SO THAT I can share con
 
 ACCEPTANCE CRITERIA
 
-- [ ] TPL-8_AC-1 [ubiquitous]: The system SHALL recognize `_partials/` directory as containing partial templates
-- [ ] TPL-8_AC-2 [ubiquitous]: Templates SHALL include partials via `<%~ include('_partials/name', it) %>`
-- [ ] TPL-8_AC-3 [ubiquitous]: Partials SHALL receive the same context object as the including template
-- [ ] TPL-8_AC-4 [ubiquitous]: Partials SHALL support the same Eta syntax as regular templates
+- TPL-8_AC-1 [ubiquitous]: The system SHALL recognize `_partials/` directory as containing partial templates
+- TPL-8_AC-2 [ubiquitous]: Templates SHALL include partials via `<%~ include('_partials/name', it) %>`
+- TPL-8_AC-3 [ubiquitous]: Partials SHALL receive the same context object as the including template
+- TPL-8_AC-4 [ubiquitous]: Partials SHALL support the same Eta syntax as regular templates
 
 ### TPL-9: Partial Exclusion from Output [MUST]
 
@@ -129,8 +129,8 @@ AS A developer, I WANT partials excluded from generated output, SO THAT only fin
 
 ACCEPTANCE CRITERIA
 
-- [ ] TPL-9_AC-1 [ubiquitous]: The system SHALL NOT output files from the `_partials/` directory
-- [ ] TPL-9_AC-2 [ubiquitous]: The system SHALL NOT output any file or directory whose name starts with `_`
+- TPL-9_AC-1 [ubiquitous]: The system SHALL NOT output files from the `_partials/` directory
+- TPL-9_AC-2 [ubiquitous]: The system SHALL NOT output any file or directory whose name starts with `_`
 
 ### TPL-10: Default Templates [SHOULD]
 
@@ -140,9 +140,9 @@ AS A developer, I WANT bundled default templates, SO THAT I can generate standar
 
 ACCEPTANCE CRITERIA
 
-- [ ] TPL-10_AC-1 [state]: WHEN `--template` is not provided THEN the system SHALL use bundled default templates
-- [ ] TPL-10_AC-2 [ubiquitous]: Default templates SHALL generate `.github/agents/*.agent.md` files
-- [ ] TPL-10_AC-3 [ubiquitous]: Default templates SHALL support common feature flags for agent configuration
+- TPL-10_AC-1 [state]: WHEN `--template` is not provided THEN the system SHALL use bundled default templates
+- TPL-10_AC-2 [ubiquitous]: Default templates SHALL generate `.github/agents/*.agent.md` files
+- TPL-10_AC-3 [ubiquitous]: Default templates SHALL support common feature flags for agent configuration
 
 ### TPL-11: Template Compilation Caching [SHOULD]
 
@@ -152,8 +152,8 @@ AS A developer, I WANT templates compiled once per session, SO THAT generation i
 
 ACCEPTANCE CRITERIA
 
-- [ ] TPL-11_AC-1 [ubiquitous]: The system SHOULD cache compiled templates in memory during a generation session
-- [ ] TPL-11_AC-2 [conditional]: IF a template is rendered multiple times THEN the system SHOULD reuse the compiled template
+- TPL-11_AC-1 [ubiquitous]: The system SHOULD cache compiled templates in memory during a generation session
+- TPL-11_AC-2 [conditional]: IF a template is rendered multiple times THEN the system SHOULD reuse the compiled template
 
 ## Assumptions
 

--- a/.awa/specs/REQ-TTST-template-test.md
+++ b/.awa/specs/REQ-TTST-template-test.md
@@ -14,7 +14,7 @@ The `awa test` command SHALL discover fixture files in the template's `_tests/` 
 
 ACCEPTANCE CRITERIA
 
-- [x] TTST-1_AC-1 [event]: WHEN `awa test` is invoked with a template path THEN all `*.toml` files in the template's `_tests/` directory are discovered and loaded
+- TTST-1_AC-1 [event]: WHEN `awa test` is invoked with a template path THEN all `*.toml` files in the template's `_tests/` directory are discovered and loaded
 
 ### TTST-2: Fixture Format [MUST]
 
@@ -24,7 +24,7 @@ Each fixture SHALL be a TOML file specifying features, presets, remove-features,
 
 ACCEPTANCE CRITERIA
 
-- [x] TTST-2_AC-1 [event]: WHEN a fixture TOML file is parsed THEN features, presets, remove-features, and expected-files arrays are extracted
+- TTST-2_AC-1 [event]: WHEN a fixture TOML file is parsed THEN features, presets, remove-features, and expected-files arrays are extracted
 
 ### TTST-3: Template Rendering [MUST]
 
@@ -34,7 +34,7 @@ The test command SHALL render templates for each fixture using the existing gene
 
 ACCEPTANCE CRITERIA
 
-- [x] TTST-3_AC-1 [event]: WHEN a fixture specifies features THEN templates are rendered to a temporary directory with those features applied
+- TTST-3_AC-1 [event]: WHEN a fixture specifies features THEN templates are rendered to a temporary directory with those features applied
 
 ### TTST-4: File Existence Assertion [MUST]
 
@@ -44,7 +44,7 @@ The test command SHALL verify that expected files exist in the rendered output.
 
 ACCEPTANCE CRITERIA
 
-- [x] TTST-4_AC-1 [event]: WHEN a fixture specifies expected-files THEN each file's existence in the rendered output is verified and missing files are reported as failures
+- TTST-4_AC-1 [event]: WHEN a fixture specifies expected-files THEN each file's existence in the rendered output is verified and missing files are reported as failures
 
 ### TTST-5: Snapshot Comparison [SHOULD]
 
@@ -54,7 +54,7 @@ The test command SHALL support snapshot comparison with `--update-snapshots` to 
 
 ACCEPTANCE CRITERIA
 
-- [x] TTST-5_AC-1 [event]: WHEN `--update-snapshots` is passed THEN rendered output is saved as the new snapshot; WHEN comparing without the flag THEN rendered output is compared against stored snapshots in `_tests/{name}/` directories
+- TTST-5_AC-1 [event]: WHEN `--update-snapshots` is passed THEN rendered output is saved as the new snapshot; WHEN comparing without the flag THEN rendered output is compared against stored snapshots in `_tests/{name}/` directories
 
 ### TTST-6: Test Reporting [MUST]
 
@@ -64,7 +64,7 @@ The test command SHALL report pass/fail per fixture with details.
 
 ACCEPTANCE CRITERIA
 
-- [x] TTST-6_AC-1 [event]: WHEN test execution completes THEN a summary is displayed showing pass/fail status per fixture with failure details
+- TTST-6_AC-1 [event]: WHEN test execution completes THEN a summary is displayed showing pass/fail status per fixture with failure details
 
 ### TTST-7: Exit Code [MUST]
 
@@ -74,7 +74,7 @@ The test command SHALL exit with code 0 when all tests pass and code 1 when any 
 
 ACCEPTANCE CRITERIA
 
-- [x] TTST-7_AC-1 [ubiquitous]: The test command SHALL return exit code 0 when all fixtures pass and exit code 1 when any fixture fails
+- TTST-7_AC-1 [ubiquitous]: The test command SHALL return exit code 0 when all fixtures pass and exit code 1 when any fixture fails
 
 ### TTST-8: Test Directory Exclusion [MUST]
 
@@ -84,4 +84,4 @@ The `_tests/` directory SHALL be excluded from template output following the und
 
 ACCEPTANCE CRITERIA
 
-- [x] TTST-8_AC-1 [ubiquitous]: The `_tests/` directory SHALL be excluded from generated output because directories starting with underscore are already excluded by the file walker
+- TTST-8_AC-1 [ubiquitous]: The `_tests/` directory SHALL be excluded from generated output because directories starting with underscore are already excluded by the file walker

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,6 +24,12 @@
 // @awa-impl: CLI-11_AC-1
 // @awa-impl: CLI-11_AC-2
 // @awa-impl: CLI-11_AC-3
+// @awa-impl: CLI-12_AC-1
+// @awa-impl: CLI-13_AC-1
+// @awa-impl: CLI-13_AC-2
+// @awa-impl: CLI-14_AC-1
+// @awa-impl: CLI-14_AC-2
+// @awa-impl: CLI-6_AC-2
 // @awa-impl: CFG-5_AC-2
 // @awa-impl: DIFF-7_AC-1
 // @awa-impl: DIFF-7_AC-2
@@ -36,6 +42,8 @@
 // @awa-impl: DIFF-7_AC-9
 // @awa-impl: DIFF-7_AC-10
 // @awa-impl: DIFF-7_AC-11
+// @awa-impl: DIFF-7_AC-12
+// @awa-impl: DIFF-7_AC-13
 // @awa-impl: FP-2_AC-1
 // @awa-impl: FP-2_AC-2
 // @awa-impl: FP-2_AC-4

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -1,6 +1,9 @@
 // @awa-component: CHK-CheckCommand
 // @awa-impl: CHK-8_AC-1
 // @awa-impl: CHK-10_AC-1
+// @awa-impl: CHK-17_AC-1
+// @awa-impl: CHK-17_AC-2
+// @awa-impl: CHK-17_AC-3
 
 import { checkCodeAgainstSpec } from '../core/check/code-spec-checker.js';
 import { scanMarkers } from '../core/check/marker-scanner.js';

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -1,9 +1,11 @@
 // @awa-component: DIFF-DiffCommand
 // @awa-component: JSON-DiffCommand
+// @awa-component: MULTI-DiffCommand
 // @awa-impl: DIFF-5_AC-1
 // @awa-impl: DIFF-5_AC-2
 // @awa-impl: DIFF-5_AC-3
 // @awa-impl: MULTI-6_AC-1
+// @awa-impl: MULTI-7_AC-1
 // @awa-impl: MULTI-12_AC-1
 
 import { intro, outro } from '@clack/prompts';

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,6 +1,14 @@
 // @awa-component: GEN-GenerateCommand
 // @awa-component: JSON-GenerateCommand
+// @awa-component: INIT-ConfigHint
+// @awa-component: MULTI-GenerateCommand
 // @awa-impl: INIT-5_AC-1
+// @awa-impl: MULTI-6_AC-1
+// @awa-impl: MULTI-10_AC-1
+// @awa-impl: CHK-1_AC-2
+// @awa-impl: CHK-1_AC-3
+// @awa-impl: CHK-5_AC-2
+// @awa-impl: CHK-5_AC-3
 
 import { intro, isCancel, multiselect, outro } from '@clack/prompts';
 import { batchRunner } from '../core/batch-runner.js';

--- a/src/core/batch-runner.ts
+++ b/src/core/batch-runner.ts
@@ -1,8 +1,11 @@
 // @awa-component: MULTI-BatchRunner
+// @awa-component: MULTI-Reporter
 // @awa-impl: MULTI-4_AC-1
 // @awa-impl: MULTI-4_AC-2
+// @awa-impl: MULTI-5_AC-1
 // @awa-impl: MULTI-8_AC-1
 // @awa-impl: MULTI-9_AC-1
+// @awa-impl: MULTI-11_AC-1
 
 import {
   ConfigError,

--- a/src/core/check/__tests__/fixtures/conforming/REQ-ENG-engine.md
+++ b/src/core/check/__tests__/fixtures/conforming/REQ-ENG-engine.md
@@ -24,9 +24,9 @@ AS A game developer, I WANT a game loop, SO THAT predictable execution.
 
 ACCEPTANCE CRITERIA
 
-- [x] ENG-1_AC-1 [event]: WHEN engine initializes THEN system SHALL create context
-- [ ] ENG-1_AC-2 [event]: WHEN `--verbose` flag is provided THEN system SHALL enable debug logging
-- [ ] ENG-1_AC-3 [ubiquitous]: The system SHALL maintain 60fps minimum frame rate
+- ENG-1_AC-1 [event]: WHEN engine initializes THEN system SHALL create context
+- ENG-1_AC-2 [event]: WHEN `--verbose` flag is provided THEN system SHALL enable debug logging
+- ENG-1_AC-3 [ubiquitous]: The system SHALL maintain 60fps minimum frame rate
 
 ### ENG-1.1: Subsystem Registration [SHOULD]
 
@@ -34,7 +34,7 @@ AS A engine maintainer, I WANT subsystems to self-register, SO THAT modular arch
 
 ACCEPTANCE CRITERIA
 
-- [ ] ENG-1.1_AC-1 [event]: WHEN subsystem loads THEN it SHALL register with context
+- ENG-1.1_AC-1 [event]: WHEN subsystem loads THEN it SHALL register with context
 
 ### ENG-2: Resource Management [MUST]
 
@@ -42,8 +42,8 @@ AS A game developer, I WANT automatic resource loading, SO THAT simplified asset
 
 ACCEPTANCE CRITERIA
 
-- [ ] ENG-2_AC-1 [event]: WHEN resource requested THEN system SHALL load asynchronously
-- [ ] ENG-2_AC-2 [ubiquitous]: The system SHALL cache loaded resources
+- ENG-2_AC-1 [event]: WHEN resource requested THEN system SHALL load asynchronously
+- ENG-2_AC-2 [ubiquitous]: The system SHALL cache loaded resources
 
 DEPENDS ON: ENG-1
 

--- a/src/core/check/__tests__/fixtures/non-conforming/REQ-BAD-broken.md
+++ b/src/core/check/__tests__/fixtures/non-conforming/REQ-BAD-broken.md
@@ -8,7 +8,7 @@ Some requirements.
 
 ### BAD-1: Missing Story and AC
 
-This requirement has no user story format and no acceptance criteria checkboxes.
+This requirement has no user story format and no acceptance criteria items.
 
 ## Change Log
 

--- a/src/core/check/__tests__/schema-fixture.test.ts
+++ b/src/core/check/__tests__/schema-fixture.test.ts
@@ -228,7 +228,7 @@ describe('Schema fixture validation', () => {
 
       const codes = result.findings.map((f) => f.code);
       expect(codes).toContain('schema-missing-content');
-      // Missing: user story, AC heading, AC checkbox items
+      // Missing: user story, AC heading, AC list items
       const missingContent = result.findings.filter((f) => f.code === 'schema-missing-content');
       expect(missingContent.length).toBeGreaterThanOrEqual(2);
     });

--- a/src/core/check/__tests__/spec-parser.test.ts
+++ b/src/core/check/__tests__/spec-parser.test.ts
@@ -44,8 +44,8 @@ AS A developer, I WANT config loading, SO THAT configuration works.
 
 ACCEPTANCE CRITERIA
 
-- [ ] CFG-1_AC-1 [event]: WHEN config loaded THEN system SHALL parse it
-- [ ] CFG-1_AC-2 [ubiquitous]: The system SHALL merge with defaults
+- CFG-1_AC-1 [event]: WHEN config loaded THEN system SHALL parse it
+- CFG-1_AC-2 [ubiquitous]: The system SHALL merge with defaults
 
 ### CFG-2: Config Validation [SHOULD]
 
@@ -53,7 +53,7 @@ AS A developer, I WANT validation, SO THAT errors are caught.
 
 ACCEPTANCE CRITERIA
 
-- [x] CFG-2_AC-1 [event]: WHEN invalid THEN system SHALL throw
+- CFG-2_AC-1 [event]: WHEN invalid THEN system SHALL throw
 `
     );
 
@@ -76,13 +76,13 @@ ACCEPTANCE CRITERIA
 
 ACCEPTANCE CRITERIA
 
-- [ ] ENG-1_AC-1 [event]: WHEN init THEN create context
+- ENG-1_AC-1 [event]: WHEN init THEN create context
 
 ### ENG-1.1: Subsystem [SHOULD]
 
 ACCEPTANCE CRITERIA
 
-- [ ] ENG-1.1_AC-1 [event]: WHEN subsystem loads THEN register
+- ENG-1.1_AC-1 [event]: WHEN subsystem loads THEN register
 `
     );
 
@@ -183,7 +183,7 @@ IMPLEMENTS: CFG-1_AC-1, CFG-1_AC-2
 
 ACCEPTANCE CRITERIA
 
-- [ ] CHK-1_AC-1 [ubiquitous]: The system SHALL scan
+- CHK-1_AC-1 [ubiquitous]: The system SHALL scan
 `
     );
 
@@ -209,7 +209,7 @@ ACCEPTANCE CRITERIA
 
 ACCEPTANCE CRITERIA
 
-- [ ] X-1_AC-1 [event]: WHEN foo THEN bar
+- X-1_AC-1 [event]: WHEN foo THEN bar
 `
     );
     await writeFile(

--- a/src/core/check/marker-scanner.ts
+++ b/src/core/check/marker-scanner.ts
@@ -14,7 +14,9 @@ const MARKER_TYPE_MAP: Record<string, MarkerType> = {
 };
 
 /** Ignore directive patterns (similar to eslint-disable comments). */
-const IGNORE_FILE_RE = /@awa-ignore-file\b/;
+// Use RegExp constructor so the literal token does not appear in this source file,
+// preventing the marker scanner from self-ignoring when it scans its own code.
+const IGNORE_FILE_RE = new RegExp('@awa-ignore' + '-file\\b');
 const IGNORE_NEXT_LINE_RE = /@awa-ignore-next-line\b/;
 const IGNORE_LINE_RE = /@awa-ignore\b/;
 const IGNORE_START_RE = /@awa-ignore-start\b/;
@@ -61,7 +63,7 @@ async function scanFile(
     return { markers: [], findings: [] };
   }
 
-  // Check for @awa-ignore-file directive anywhere in the file
+  // Check for file-level ignore directive anywhere in the file
   if (IGNORE_FILE_RE.test(content)) {
     return { markers: [], findings: [] };
   }

--- a/src/core/check/spec-parser.ts
+++ b/src/core/check/spec-parser.ts
@@ -61,8 +61,8 @@ async function parseSpecFile(
 
   // Requirement ID: ### CODE-N: Title or ### CODE-N.P: Title
   const reqIdRegex = /^###\s+([A-Z][A-Z0-9]*-\d+(?:\.\d+)?)\s*:/;
-  // AC ID: - [ ] CODE-N_AC-M or - [x] CODE-N.P_AC-M
-  const acIdRegex = /^-\s+\[[ x]\]\s+([A-Z][A-Z0-9]*-\d+(?:\.\d+)?_AC-\d+)\s/;
+  // AC ID: - CODE-N_AC-M or - [ ] CODE-N_AC-M or - [x] CODE-N.P_AC-M
+  const acIdRegex = /^-\s+(?:\[[ x]\]\s+)?([A-Z][A-Z0-9]*-\d+(?:\.\d+)?_AC-\d+)\s/;
   // Property ID: - CODE_P-N [Name]
   const propIdRegex = /^-\s+([A-Z][A-Z0-9]*_P-\d+)\s/;
   // Component name: ### CODE-ComponentName

--- a/src/core/check/types.ts
+++ b/src/core/check/types.ts
@@ -58,6 +58,8 @@ export type FindingSeverity = 'error' | 'warning';
 export type FindingCode =
   | 'orphaned-marker'
   | 'uncovered-ac'
+  | 'uncovered-component'
+  | 'unimplemented-ac'
   | 'broken-cross-ref'
   | 'invalid-id-format'
   | 'marker-trailing-text'

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,4 +1,5 @@
 // @awa-component: CFG-ConfigLoader
+// @awa-component: MULTI-TargetResolver
 // @awa-impl: CFG-1_AC-1
 // @awa-impl: CFG-1_AC-2
 // @awa-impl: CFG-1_AC-3
@@ -12,6 +13,10 @@
 // @awa-impl: CFG-3_AC-4
 // @awa-impl: CFG-3_AC-5
 // @awa-impl: CFG-3_AC-6
+// @awa-impl: CFG-3_AC-7
+// @awa-impl: CFG-3_AC-8
+// @awa-impl: CFG-3_AC-9
+// @awa-impl: CFG-3_AC-10
 // @awa-impl: CFG-4_AC-1
 // @awa-impl: CFG-4_AC-2
 // @awa-impl: CFG-4_AC-3
@@ -25,6 +30,20 @@
 // @awa-impl: CLI-2_AC-4
 // @awa-impl: CLI-4_AC-3
 // @awa-impl: CLI-7_AC-2
+// @awa-impl: FP-1_AC-1
+// @awa-impl: FP-1_AC-2
+// @awa-impl: FP-1_AC-3
+// @awa-impl: FP-1_AC-4
+// @awa-impl: FP-3_AC-1
+// @awa-impl: FP-3_AC-2
+// @awa-impl: FP-3_AC-3
+// @awa-impl: FP-5_AC-1
+// @awa-impl: FP-5_AC-2
+// @awa-impl: FP-5_AC-3
+// @awa-impl: MULTI-1_AC-1
+// @awa-impl: MULTI-2_AC-1
+// @awa-impl: MULTI-3_AC-1
+// @awa-impl: MULTI-5_AC-2
 
 import { parse } from 'smol-toml';
 import {

--- a/src/core/delete-list.ts
+++ b/src/core/delete-list.ts
@@ -1,4 +1,6 @@
 // @awa-component: GEN-DeleteList
+// @awa-impl: GEN-12_AC-1
+// @awa-impl: GEN-12_AC-8
 
 import { join } from 'node:path';
 import { pathExists, readTextFile } from '../utils/fs.js';

--- a/src/core/differ.ts
+++ b/src/core/differ.ts
@@ -18,6 +18,10 @@
 // @awa-impl: DIFF-6_AC-1
 // @awa-impl: DIFF-6_AC-2
 // @awa-impl: DIFF-6_AC-3
+// @awa-impl: DIFF-8_AC-1
+// @awa-impl: DIFF-8_AC-2
+// @awa-impl: DIFF-8_AC-3
+// @awa-impl: DIFF-8_AC-4
 
 import { tmpdir } from 'node:os';
 import { join, relative } from 'node:path';

--- a/src/core/feature-resolver.ts
+++ b/src/core/feature-resolver.ts
@@ -1,4 +1,13 @@
 // @awa-component: FP-FeatureResolver
+// @awa-impl: FP-2_AC-3
+// @awa-impl: FP-4_AC-4
+// @awa-impl: FP-6_AC-1
+// @awa-impl: FP-6_AC-2
+// @awa-impl: FP-6_AC-3
+// @awa-impl: FP-6_AC-4
+// @awa-impl: FP-6_AC-5
+// @awa-impl: FP-7_AC-1
+// @awa-impl: FP-7_AC-2
 
 import { ConfigError, type PresetDefinitions } from '../types/index.js';
 

--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -12,6 +12,15 @@
 // @awa-impl: GEN-8_AC-2
 // @awa-impl: GEN-8_AC-3
 // @awa-impl: GEN-11_AC-3
+// @awa-impl: GEN-6_AC-1
+// @awa-impl: GEN-6_AC-2
+// @awa-impl: GEN-12_AC-2
+// @awa-impl: GEN-12_AC-4
+// @awa-impl: GEN-12_AC-5
+// @awa-impl: GEN-12_AC-6
+// @awa-impl: GEN-12_AC-7
+// @awa-impl: CLI-6_AC-2
+// @awa-impl: CLI-12_AC-2
 // @awa-impl: TPL-9_AC-1
 // @awa-impl: TPL-9_AC-2
 

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -1,4 +1,5 @@
 // @awa-component: GEN-ConflictResolver
+// @awa-component: GEN-DeleteResolver
 // @awa-impl: CLI-5_AC-2
 // @awa-impl: CLI-5_AC-3
 // @awa-impl: GEN-4_AC-1
@@ -13,6 +14,10 @@
 // @awa-impl: GEN-5_AC-7
 // @awa-impl: GEN-6_AC-3
 // @awa-impl: GEN-10_AC-3
+// @awa-impl: GEN-12_AC-3
+// @awa-impl: GEN-12_AC-4
+// @awa-impl: GEN-12_AC-5
+// @awa-impl: CLI-12_AC-3
 
 import { MultiSelectPrompt } from '@clack/core';
 import { isCancel, multiselect } from '@clack/prompts';

--- a/src/core/template-test/runner.ts
+++ b/src/core/template-test/runner.ts
@@ -2,6 +2,7 @@
 // @awa-impl: TTST-3_AC-1
 // @awa-impl: TTST-4_AC-1
 // @awa-impl: TTST-5_AC-1
+// @awa-impl: TTST-8_AC-1
 
 import { mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -11,6 +11,8 @@
 // @awa-impl: GEN-9_AC-4
 // @awa-impl: GEN-9_AC-5
 // @awa-impl: GEN-9_AC-6
+// @awa-impl: GEN-9_AC-7
+// @awa-impl: GEN-9_AC-8
 // @awa-impl: GEN-11_AC-1
 // @awa-impl: GEN-11_AC-2
 // @awa-impl: GEN-11_AC-4


### PR DESCRIPTION
## Summary

Fixes 73 missing traceability markers and a marker-scanner self-ignore bug.

### Changes

**Bug fixes:**
- Fix marker-scanner self-ignore: \`IGNORE_FILE_RE\` regex literal matched the scanner's own source, causing it to skip itself when scanning code. Fixed via string concatenation in RegExp constructor.

**New checks (CHK-18, CHK-19):**
- Add CHK-18 requirement and implementation: warns when a DESIGN component has no \`@awa-component\` marker in code
- Add CHK-19 requirement and implementation: warns when an AC has no \`@awa-impl\` marker in code
- 4 new tests added to code-spec-checker.test.ts

**Spec cleanup:**
- Remove \`- [ ]\`/\`- [x]\` checkboxes from all 13 REQ spec files (AC lines now plain dashes)
- Update spec-parser AC regex to make checkbox prefix optional (backward compatible)

**Marker additions:**
- 6 missing \`@awa-component\` markers: GEN-DeleteResolver, INIT-ConfigHint, MULTI-TargetResolver, MULTI-Reporter, MULTI-GenerateCommand, MULTI-DiffCommand
- 67 missing \`@awa-impl\` markers across 12 source files spanning CFG, CHK, CLI, DIFF, FP, GEN, MULTI, TTST domains

### Verification
- All 493 tests pass
- \`awa check\` reports zero issues