### PR TITLE
fix: gather traceability markers correctly from multiple REQ-* files with same code

### DIFF
--- a/src/core/check/__tests__/matrix-fixer.test.ts
+++ b/src/core/check/__tests__/matrix-fixer.test.ts
@@ -279,6 +279,114 @@ IMPLEMENTS: GEN-1_AC-1, CLI-1_AC-1
       expect(content).toContain('- GEN-1_AC-1 → GEN-FileGenerator (GEN_P-1)');
     });
 
+    test('handles multiple REQ files sharing the same code prefix', async () => {
+      const designPath = join(specDir, 'DESIGN-ARC-security.md');
+      await writeFile(
+        designPath,
+        `# Design Specification
+
+## Overview
+
+Test design with shared code prefix.
+
+## Components and Interfaces
+
+### ARC-SecurityChecker
+
+Checks security.
+
+IMPLEMENTS: ARC-30_AC-1, ARC-30_AC-2
+
+### ARC-FlowEngine
+
+Runs flows.
+
+IMPLEMENTS: ARC-10_AC-1
+
+## Correctness Properties
+
+- ARC_P-1 [Security Invariant]: Security property
+  VALIDATES: ARC-30_AC-1
+
+## Requirements Traceability
+
+### placeholder
+
+- old
+`
+      );
+
+      // Two REQ files sharing the ARC code prefix
+      const reqSecurity = join(specDir, 'REQ-ARC-security.md');
+      await writeFile(
+        reqSecurity,
+        `### ARC-30: User Identity [MUST]
+
+ACCEPTANCE CRITERIA
+
+- ARC-30_AC-1 [ubiquitous]: The system SHALL verify identity
+- ARC-30_AC-2 [event]: WHEN login THEN system SHALL authenticate
+`
+      );
+
+      const reqFlows = join(specDir, 'REQ-ARC-flows.md');
+      await writeFile(
+        reqFlows,
+        `### ARC-10: Minting Flows [MUST]
+
+ACCEPTANCE CRITERIA
+
+- ARC-10_AC-1 [event]: WHEN minting THEN system SHALL create token
+`
+      );
+
+      const specs = makeSpecs([
+        {
+          filePath: reqSecurity,
+          code: 'ARC',
+          requirementIds: ['ARC-30'],
+          acIds: ['ARC-30_AC-1', 'ARC-30_AC-2'],
+          propertyIds: [],
+          componentNames: [],
+          crossRefs: [],
+        },
+        {
+          filePath: reqFlows,
+          code: 'ARC',
+          requirementIds: ['ARC-10'],
+          acIds: ['ARC-10_AC-1'],
+          propertyIds: [],
+          componentNames: [],
+          crossRefs: [],
+        },
+        {
+          filePath: designPath,
+          code: 'ARC',
+          requirementIds: [],
+          acIds: [],
+          propertyIds: ['ARC_P-1'],
+          componentNames: ['ARC-SecurityChecker', 'ARC-FlowEngine'],
+          crossRefs: [],
+          componentImplements: new Map([
+            ['ARC-SecurityChecker', ['ARC-30_AC-1', 'ARC-30_AC-2']],
+            ['ARC-FlowEngine', ['ARC-10_AC-1']],
+          ]),
+        },
+      ]);
+
+      await fixMatrices(specs, ['IMPLEMENTS:', 'VALIDATES:']);
+      const content = await readFile(designPath, 'utf-8');
+
+      // Each REQ file should have its own heading — NOT all under one file
+      expect(content).toContain('### REQ-ARC-security.md');
+      expect(content).toContain('### REQ-ARC-flows.md');
+      // ACs should be under the correct headings
+      expect(content).toContain('- ARC-30_AC-1 → ARC-SecurityChecker');
+      expect(content).toContain('- ARC-10_AC-1 → ARC-FlowEngine');
+      // Should NOT have placeholder content
+      expect(content).not.toContain('placeholder');
+    });
+
     test('no-ops when no Requirements Traceability section exists', async () => {
       const designPath = join(specDir, 'DESIGN-X-x.md');
       const original = `# Design Specification
@@ -442,6 +550,142 @@ ACCEPTANCE CRITERIA
       // Old content should be gone
       expect(taskContent).not.toContain('PLACEHOLDER');
       expect(taskContent).not.toContain('old content');
+    });
+
+    test('handles multiple REQ files sharing the same code prefix', async () => {
+      const taskPath = join(testDir, '.awa', 'tasks', 'TASK-ARC-security-001.md');
+      await mkdir(join(testDir, '.awa', 'tasks'), { recursive: true });
+      await writeFile(
+        taskPath,
+        `# Implementation Tasks
+
+FEATURE: Security
+SOURCE: REQ-ARC-security.md, REQ-ARC-flows.md, DESIGN-ARC-security.md
+
+## Phase 1: Security [MUST]
+
+GOAL: Implement security
+TEST CRITERIA: Security works
+
+- [ ] T-ARC-010 [ARC-30] Implement identity → src/security.ts
+  IMPLEMENTS: ARC-30_AC-1
+- [ ] T-ARC-011 [ARC-10] Implement flows → src/flows.ts
+  IMPLEMENTS: ARC-10_AC-1
+- [ ] T-ARC-012 [P] [ARC-30] Test security property → tests/security.test.ts
+  TESTS: ARC_P-1
+
+---
+
+## Dependencies
+
+ARC-30 → (none)
+ARC-10 → (none)
+
+## Parallel Opportunities
+
+Phase 1: T-ARC-010, T-ARC-011 can run parallel
+
+## Requirements Traceability
+
+### placeholder
+
+- old
+`
+      );
+
+      const reqSecurity = join(specDir, 'REQ-ARC-security.md');
+      await writeFile(
+        reqSecurity,
+        `### ARC-30: User Identity [MUST]
+
+ACCEPTANCE CRITERIA
+
+- ARC-30_AC-1 [ubiquitous]: The system SHALL verify identity
+`
+      );
+
+      const reqFlows = join(specDir, 'REQ-ARC-flows.md');
+      await writeFile(
+        reqFlows,
+        `### ARC-10: Minting Flows [MUST]
+
+ACCEPTANCE CRITERIA
+
+- ARC-10_AC-1 [event]: WHEN minting THEN system SHALL create token
+`
+      );
+
+      const designPath = join(specDir, 'DESIGN-ARC-security.md');
+      await writeFile(
+        designPath,
+        `# Design
+
+## Correctness Properties
+
+- ARC_P-1 [Security Invariant]: Security property
+  VALIDATES: ARC-30_AC-1
+
+## Requirements Traceability
+
+### REQ-ARC-security.md
+
+- stub
+`
+      );
+
+      const specs = makeSpecs([
+        {
+          filePath: reqSecurity,
+          code: 'ARC',
+          requirementIds: ['ARC-30'],
+          acIds: ['ARC-30_AC-1'],
+          propertyIds: [],
+          componentNames: [],
+          crossRefs: [],
+        },
+        {
+          filePath: reqFlows,
+          code: 'ARC',
+          requirementIds: ['ARC-10'],
+          acIds: ['ARC-10_AC-1'],
+          propertyIds: [],
+          componentNames: [],
+          crossRefs: [],
+        },
+        {
+          filePath: designPath,
+          code: 'ARC',
+          requirementIds: [],
+          acIds: [],
+          propertyIds: ['ARC_P-1'],
+          componentNames: [],
+          crossRefs: [],
+        },
+        {
+          filePath: taskPath,
+          code: 'ARC',
+          requirementIds: [],
+          acIds: [],
+          propertyIds: [],
+          componentNames: [],
+          crossRefs: [
+            { type: 'implements', ids: ['ARC-30_AC-1'], filePath: taskPath, line: 14 },
+            { type: 'implements', ids: ['ARC-10_AC-1'], filePath: taskPath, line: 16 },
+          ],
+        },
+      ]);
+
+      await fixMatrices(specs, ['IMPLEMENTS:', 'VALIDATES:']);
+      const content = await readFile(taskPath, 'utf-8');
+
+      // Each REQ file should have its own heading — NOT all under REQ-ARC-security.md
+      expect(content).toContain('### REQ-ARC-security.md');
+      expect(content).toContain('### REQ-ARC-flows.md');
+      // ACs should be under correct headings
+      expect(content).toContain('- ARC-30_AC-1 → T-ARC-010');
+      expect(content).toContain('- ARC-10_AC-1 → T-ARC-011');
+      // Should NOT have placeholder
+      expect(content).not.toContain('placeholder');
     });
 
     // @awa-test: CHK_P-12

--- a/src/core/check/matrix-fixer.ts
+++ b/src/core/check/matrix-fixer.ts
@@ -26,22 +26,17 @@ export async function fixMatrices(
   specs: SpecParseResult,
   crossRefPatterns: readonly string[]
 ): Promise<FixResult> {
-  const codeToReqFile = buildCodeToReqFileMap(specs.specFiles);
+  const reqFileMaps = buildReqFileMaps(specs.specFiles);
   const fileResults: FileFixResult[] = [];
 
   for (const specFile of specs.specFiles) {
     const fileName = basename(specFile.filePath);
 
     if (fileName.startsWith('DESIGN-')) {
-      const changed = await fixDesignMatrix(specFile.filePath, codeToReqFile, crossRefPatterns);
+      const changed = await fixDesignMatrix(specFile.filePath, reqFileMaps, crossRefPatterns);
       fileResults.push({ filePath: specFile.filePath, changed });
     } else if (fileName.startsWith('TASK-')) {
-      const changed = await fixTaskMatrix(
-        specFile.filePath,
-        codeToReqFile,
-        specs,
-        crossRefPatterns
-      );
+      const changed = await fixTaskMatrix(specFile.filePath, reqFileMaps, specs, crossRefPatterns);
       fileResults.push({ filePath: specFile.filePath, changed });
     }
   }
@@ -52,21 +47,79 @@ export async function fixMatrices(
   };
 }
 
-// --- Code prefix → REQ filename map ---
+// --- ID → REQ filename maps ---
 
-function buildCodeToReqFileMap(specFiles: readonly SpecFile[]): Map<string, string> {
-  const map = new Map<string, string>();
-  for (const sf of specFiles) {
-    if (/\bREQ-/.test(basename(sf.filePath)) && sf.code) {
-      map.set(sf.code, basename(sf.filePath));
-    }
-  }
-  return map;
+interface ReqFileMaps {
+  /** Maps each requirement ID and AC ID to the REQ file that defines it. */
+  readonly idToReqFile: Map<string, string>;
+  /** Maps code prefix to sorted list of REQ filenames (fallback for property IDs). */
+  readonly codeToReqFiles: Map<string, string[]>;
 }
 
-function getCodePrefix(id: string): string {
-  const match = /^([A-Z][A-Z0-9]*)[-_]/.exec(id);
-  return match?.[1] ?? '';
+/**
+ * Build maps from requirement/AC IDs and code prefixes to REQ filenames.
+ * The per-ID map correctly handles multiple REQ files sharing the same code
+ * prefix (e.g. REQ-ARC-flows.md and REQ-ARC-security.md both using ARC-* IDs).
+ */
+function buildReqFileMaps(specFiles: readonly SpecFile[]): ReqFileMaps {
+  const idToReqFile = new Map<string, string>();
+  const codeToReqFilesSet = new Map<string, Set<string>>();
+
+  for (const sf of specFiles) {
+    const fileName = basename(sf.filePath);
+    if (!/\bREQ-/.test(fileName)) continue;
+
+    // Map each requirement ID and AC ID to this REQ file
+    for (const reqId of sf.requirementIds) {
+      idToReqFile.set(reqId, fileName);
+    }
+    for (const acId of sf.acIds) {
+      idToReqFile.set(acId, fileName);
+    }
+
+    // Build code → REQ files multimap for property ID fallback
+    if (sf.code) {
+      const existing = codeToReqFilesSet.get(sf.code) ?? new Set<string>();
+      existing.add(fileName);
+      codeToReqFilesSet.set(sf.code, existing);
+    }
+  }
+
+  // Convert sets to sorted arrays for deterministic output
+  const codeToReqFiles = new Map<string, string[]>();
+  for (const [code, files] of codeToReqFilesSet) {
+    codeToReqFiles.set(code, [...files].sort());
+  }
+
+  return { idToReqFile, codeToReqFiles };
+}
+
+/**
+ * Resolve an ID to its REQ file.
+ * - Requirement IDs and AC IDs: direct lookup via idToReqFile
+ * - AC IDs not found directly: strip _AC-N suffix and look up parent requirement
+ * - Property IDs (CODE_P-N): code prefix fallback via codeToReqFiles
+ *   (when one REQ file for the code, it's unambiguous; with multiple, uses first sorted)
+ */
+function resolveReqFile(id: string, maps: ReqFileMaps): string | undefined {
+  // Direct lookup (works for both requirement IDs and AC IDs)
+  const direct = maps.idToReqFile.get(id);
+  if (direct) return direct;
+
+  // For AC IDs, try parent requirement: strip _AC-N suffix
+  const acMatch = /^(.+)_AC-\d+$/.exec(id);
+  if (acMatch?.[1]) {
+    return maps.idToReqFile.get(acMatch[1]);
+  }
+
+  // For property IDs (CODE_P-N), fall back to code prefix
+  const propMatch = /^([A-Z][A-Z0-9]*)_P-\d+$/.exec(id);
+  if (propMatch?.[1]) {
+    const files = maps.codeToReqFiles.get(propMatch[1]);
+    return files?.[0];
+  }
+
+  return undefined;
 }
 
 // --- DESIGN matrix ---
@@ -83,7 +136,7 @@ interface PropertyInfo {
 
 async function fixDesignMatrix(
   filePath: string,
-  codeToReqFile: Map<string, string>,
+  reqFileMaps: ReqFileMaps,
   crossRefPatterns: readonly string[]
 ): Promise<boolean> {
   let content: string;
@@ -117,7 +170,7 @@ async function fixDesignMatrix(
 
   // Group ACs by REQ file
   const allAcIds = [...acToComponents.keys()];
-  const grouped = groupByReqFile(allAcIds, codeToReqFile);
+  const grouped = groupByReqFile(allAcIds, reqFileMaps);
 
   const newSection = generateDesignSection(grouped, acToComponents, acToProperties);
   const newContent = replaceTraceabilitySection(content, newSection);
@@ -230,7 +283,7 @@ interface TaskInfo {
 
 async function fixTaskMatrix(
   filePath: string,
-  codeToReqFile: Map<string, string>,
+  reqFileMaps: ReqFileMaps,
   specs: SpecParseResult,
   crossRefPatterns: readonly string[]
 ): Promise<boolean> {
@@ -276,7 +329,7 @@ async function fixTaskMatrix(
 
   // Group ACs and properties by REQ file
   const allIdsForMatrix = [...new Set([...acToTasks.keys(), ...idToTestTasks.keys()])];
-  const grouped = groupByReqFile(allIdsForMatrix, codeToReqFile);
+  const grouped = groupByReqFile(allIdsForMatrix, reqFileMaps);
 
   const newSection = generateTaskSection(grouped, acToTasks, idToTestTasks, sourcePropertyIds);
   const newContent = replaceTraceabilitySection(content, newSection);
@@ -417,11 +470,10 @@ function generateTaskSection(
 
 // --- Shared utilities ---
 
-function groupByReqFile(ids: string[], codeToReqFile: Map<string, string>): Map<string, string[]> {
+function groupByReqFile(ids: string[], maps: ReqFileMaps): Map<string, string[]> {
   const groups = new Map<string, string[]>();
   for (const id of ids) {
-    const code = getCodePrefix(id);
-    const reqFile = codeToReqFile.get(code);
+    const reqFile = resolveReqFile(id, maps);
     if (!reqFile) continue; // Skip IDs we can't resolve to a REQ file
     const existing = groups.get(reqFile) ?? [];
     existing.push(id);


### PR DESCRIPTION
Fixes marker gathering logic so that traceability markers are correctly collected from multiple REQ-\* files sharing the same feature code.