### PR TITLE
fix: accept checked checkboxes in TASK schema validation

### DIFF
--- a/.awa/.agent/schemas/TASK.schema.yaml
+++ b/.awa/.agent/schemas/TASK.schema.yaml
@@ -41,14 +41,15 @@ sections:
     contains:
       # Tasks as checkbox items: "- [ ] T-{CODE}-{nnn} ... → path"
       - list:
-          pattern: "\\[ \\] T-[A-Z][A-Z0-9]*-\\d+"
+          pattern: "\\[[ x]\\] T-[A-Z][A-Z0-9]*-\\d+"
           min: 1
           label: "task checkbox items"
         description: >
-          Task items as unchecked checkboxes. Format:
+          Task items as checkboxes. Format:
           - [ ] T-{CODE}-{nnn} [P]? [{CODE}-{n}]? Description → target/path.
           [P] marks parallelizable tasks. [{CODE}-{n}] is the requirement ID
-          (only on requirement phases). Always unchecked in generated output.
+          (only on requirement phases). Always unchecked when generating tasks;
+          checked boxes ([x]) are filled during task list implementation.
       # Tasks must have file path targets (→)
       - pattern: "→"
         label: "file path targets"

--- a/.github/agents/awa.agent.md
+++ b/.github/agents/awa.agent.md
@@ -1,5 +1,5 @@
 ---
-description: "awa 1.8.0"
+description: "awa 1.8.3"
 tools: ['edit', 'search', 'runCommands', 'runTasks', 'microsoft/playwright-mcp/*', 'usages', 'vscodeAPI', 'problems', 'changes', 'testFailure', 'openSimpleBrowser', 'fetch', 'githubRepo', 'extensions', 'todos', 'runTests']
 ---
 

--- a/templates/awa/.awa/.agent/schemas/TASK.schema.yaml
+++ b/templates/awa/.awa/.agent/schemas/TASK.schema.yaml
@@ -41,14 +41,15 @@ sections:
     contains:
       # Tasks as checkbox items: "- [ ] T-{CODE}-{nnn} ... → path"
       - list:
-          pattern: "\\[ \\] T-[A-Z][A-Z0-9]*-\\d+"
+          pattern: "\\[[ x]\\] T-[A-Z][A-Z0-9]*-\\d+"
           min: 1
           label: "task checkbox items"
         description: >
-          Task items as unchecked checkboxes. Format:
+          Task items as checkboxes. Format:
           - [ ] T-{CODE}-{nnn} [P]? [{CODE}-{n}]? Description → target/path.
           [P] marks parallelizable tasks. [{CODE}-{n}] is the requirement ID
-          (only on requirement phases). Always unchecked in generated output.
+          (only on requirement phases). Always unchecked when generating tasks;
+          checked boxes ([x]) are filled during task list implementation.
       # Tasks must have file path targets (→)
       - pattern: "→"
         label: "file path targets"

--- a/templates/awa/_tests/claude/.awa/.agent/schemas/TASK.schema.yaml
+++ b/templates/awa/_tests/claude/.awa/.agent/schemas/TASK.schema.yaml
@@ -41,14 +41,15 @@ sections:
     contains:
       # Tasks as checkbox items: "- [ ] T-{CODE}-{nnn} ... → path"
       - list:
-          pattern: "\\[ \\] T-[A-Z][A-Z0-9]*-\\d+"
+          pattern: "\\[[ x]\\] T-[A-Z][A-Z0-9]*-\\d+"
           min: 1
           label: "task checkbox items"
         description: >
-          Task items as unchecked checkboxes. Format:
+          Task items as checkboxes. Format:
           - [ ] T-{CODE}-{nnn} [P]? [{CODE}-{n}]? Description → target/path.
           [P] marks parallelizable tasks. [{CODE}-{n}] is the requirement ID
-          (only on requirement phases). Always unchecked in generated output.
+          (only on requirement phases). Always unchecked when generating tasks;
+          checked boxes ([x]) are filled during task list implementation.
       # Tasks must have file path targets (→)
       - pattern: "→"
         label: "file path targets"

--- a/templates/awa/_tests/copilot/.awa/.agent/schemas/TASK.schema.yaml
+++ b/templates/awa/_tests/copilot/.awa/.agent/schemas/TASK.schema.yaml
@@ -41,14 +41,15 @@ sections:
     contains:
       # Tasks as checkbox items: "- [ ] T-{CODE}-{nnn} ... → path"
       - list:
-          pattern: "\\[ \\] T-[A-Z][A-Z0-9]*-\\d+"
+          pattern: "\\[[ x]\\] T-[A-Z][A-Z0-9]*-\\d+"
           min: 1
           label: "task checkbox items"
         description: >
-          Task items as unchecked checkboxes. Format:
+          Task items as checkboxes. Format:
           - [ ] T-{CODE}-{nnn} [P]? [{CODE}-{n}]? Description → target/path.
           [P] marks parallelizable tasks. [{CODE}-{n}] is the requirement ID
-          (only on requirement phases). Always unchecked in generated output.
+          (only on requirement phases). Always unchecked when generating tasks;
+          checked boxes ([x]) are filled during task list implementation.
       # Tasks must have file path targets (→)
       - pattern: "→"
         label: "file path targets"


### PR DESCRIPTION
The TASK schema list pattern \`\\[ \\] T-{CODE}-{nnn}\` only matched unchecked checkboxes. When users mark tasks as done (\`[x]\`), \`awa check --spec-only\` would fail.

**Changes:**
- Widened the checkbox pattern from \`\\[ \\]\` to \`\\[[ x]\\]\` so both unchecked and checked boxes pass validation
- Updated description to clarify that checked boxes are accepted during validation while generated output should remain unchecked
- Applied to all 4 copies: local \`.awa/\`, template source, and both test fixtures (claude, copilot)